### PR TITLE
evernote-2026-05-01: add Evernote-to-Notion migration tool

### DIFF
--- a/evernote-2026-05-01/.env.example
+++ b/evernote-2026-05-01/.env.example
@@ -1,0 +1,11 @@
+# Notion internal integration token
+# https://www.notion.so/my-integrations
+NOTION_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# The ID of the Notion page that will be the parent of the migration database.
+# Required when creating a new database. Share that page with the integration.
+NOTION_PARENT_PAGE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Optional: existing Notion database ID to reuse (skip database creation).
+# If set, NOTION_PARENT_PAGE_ID is not required.
+# NOTION_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/evernote-2026-05-01/.gitignore
+++ b/evernote-2026-05-01/.gitignore
@@ -1,0 +1,5 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/evernote-2026-05-01/README.md
+++ b/evernote-2026-05-01/README.md
@@ -1,0 +1,100 @@
+# evernote-2026-05-01
+
+Evernote の `.enex` エクスポートを Notion データベースへ移行するツール。
+Notion 公式インポートでは失われてしまう **元の Evernote GUID** や **作成・更新日時、ソース URL、リマインダー、ジオ情報、ノートブック由来の情報** をすべてデータベースの列として保存することを目的としている。
+
+## 何が嬉しいか
+
+公式インポーターは Evernote 内部の GUID を保存しないため、後から「Evernote 上のあのノート ＝ Notion のこのページ」という対応が取れない。
+このツールでは以下のように Evernote GUID を含めた列で Notion DB を構築し、再実行時には GUID で重複を検知してスキップする。
+
+| 列名 | 型 | 内容 |
+| --- | --- | --- |
+| Title | title | ノートタイトル |
+| Evernote GUID | rich_text | Evernote の GUID（取れない時は `sha1:...` の決定論的 ID） |
+| Evernote GUID Source | select | GUID の取得元（`source-url` / `application-data` / `sha1-fallback` / `missing`） |
+| Source URL | url | `evernote://...` などの元 URL |
+| Source / Source Application / Author | rich_text | 各 Evernote 属性 |
+| Created / Updated | date | Evernote 上の作成・更新日時 |
+| Tags | multi_select | タグ |
+| Reminder / Reminder Done | date | リマインダー |
+| Latitude / Longitude / Altitude | number | ジオ情報 |
+| Source File | rich_text | 元 `.enex` ファイル名 |
+| Migrated At | date | 移行実行時刻 |
+| Migration Status | select | Success / Partial / Failed |
+
+## Evernote GUID の取得元
+
+ENEX フォーマット自体には GUID 専用フィールドは無いが、以下の場所から復元できる:
+
+1. `<note-attributes><source-url>` の `evernote:///view/<userId>/<shardId>/<GUID>/<GUID>/`
+2. `<note-attributes><application-data key="evernote.guid">...</application-data>` などのキー
+3. 上記いずれも無い場合は `title|created|content[:512]` の SHA-1 を `sha1:...` として保存（決定論的なので再実行で同じ ID になる）
+
+このため Evernote 公式アプリでエクスポートしたファイルはほぼ確実に GUID を保存できる。
+
+## セットアップ
+
+```bash
+# 1. mise で uv を入れる
+mise install
+
+# 2. .env を準備
+cp .env.example .env
+# .env を編集して NOTION_TOKEN, NOTION_PARENT_PAGE_ID を設定
+
+# 3. 依存解決
+uv sync
+```
+
+Notion 側の準備:
+
+1. <https://www.notion.so/my-integrations> で internal integration を作って `secret_...` トークンを取得
+2. データベースの親になるページを作り、そのページの右上「...」→ Connections から作った integration を接続
+3. ページ URL の末尾の 32 桁 (`https://www.notion.so/Some-Page-<32hex>`) が `NOTION_PARENT_PAGE_ID`
+
+## 使い方
+
+```bash
+# まずは dry-run でパース結果（GUID が取れているか）を確認
+uv run python migrate.py path/to/notes.enex --dry-run --limit 3
+
+# 本番実行
+uv run python migrate.py path/to/notes.enex
+
+# 既存 DB を再利用したいなら .env に NOTION_DATABASE_ID を入れて実行
+NOTION_DATABASE_ID=xxxxx uv run python migrate.py path/to/notes.enex
+
+# 複数ファイルもまとめて
+uv run python migrate.py exports/*.enex
+```
+
+`mise` タスク経由でも:
+
+```bash
+mise run migrate -- path/to/notes.enex
+mise run test
+```
+
+## 仕組み
+
+| ファイル | 役割 |
+| --- | --- |
+| `enex_parser.py` | `.enex` をストリーム解析し `Note` データクラスに変換。GUID 復元はここ |
+| `enml_converter.py` | ENML (Evernote の HTML 方言) を Notion の block JSON に変換 |
+| `notion_migrator.py` | Notion DB の作成・スキーマ定義・ページ作成・重複検知 |
+| `migrate.py` | CLI |
+
+## 制限事項
+
+- `<en-media>` で参照されている **添付ファイル** は Notion API 仕様上、外部 URL からしか取り込めないため、現状は callout ブロックで「添付があった事実」と MIME / hash を残すに留めている。必要なら別途 S3 等にアップロードしてその URL を埋め込むよう拡張する。
+- ENML のテーブルはプレーンテキスト化している（Notion の table block は構造が複雑なため）。
+- Notion の rich_text は 1 セグメント 2000 文字までなのでチャンク分割している。
+
+## テスト
+
+```bash
+uv run pytest -v
+```
+
+サンプル `.enex` を `tests/sample.enex` に同梱しているので、Notion トークンが無い環境でもパーサと ENML 変換は確認できる。

--- a/evernote-2026-05-01/enex_parser.py
+++ b/evernote-2026-05-01/enex_parser.py
@@ -1,0 +1,214 @@
+"""Parse Evernote .enex export files into structured Note objects.
+
+The official Notion importer drops the original Evernote GUID, so this parser
+goes out of its way to recover it. The GUID is most reliably stored in the
+``<note-attributes><source-url>`` field as an ``evernote:///view/...`` URL.
+When that is missing we fall back to ``<application-data>`` keys, and finally
+to a deterministic SHA-1 hash of (title|created|content) so every note still
+has a stable, replayable identifier.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+from dateutil import parser as dateparser
+from lxml import etree
+
+
+EVERNOTE_URL_GUID_RE = re.compile(
+    r"evernote:/+view/\d+/[^/]+/([0-9a-f-]{8,})/", re.IGNORECASE
+)
+
+
+@dataclass(slots=True)
+class Resource:
+    mime: str | None = None
+    filename: str | None = None
+    hash_md5: str | None = None
+    size: int | None = None
+
+
+@dataclass(slots=True)
+class Note:
+    title: str
+    content_enml: str
+    created: datetime | None = None
+    updated: datetime | None = None
+    tags: list[str] = field(default_factory=list)
+    source_url: str | None = None
+    source: str | None = None
+    source_application: str | None = None
+    author: str | None = None
+    reminder_time: datetime | None = None
+    reminder_done_time: datetime | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    altitude: float | None = None
+    evernote_guid: str | None = None
+    evernote_guid_source: str = "unknown"
+    application_data: dict[str, str] = field(default_factory=dict)
+    resources: list[Resource] = field(default_factory=list)
+    raw_attributes: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def stable_id(self) -> str:
+        """Return the Evernote GUID if known, otherwise a deterministic hash."""
+        if self.evernote_guid:
+            return self.evernote_guid
+        digest = hashlib.sha1(
+            "|".join(
+                [
+                    self.title or "",
+                    self.created.isoformat() if self.created else "",
+                    self.content_enml[:512],
+                ]
+            ).encode("utf-8")
+        ).hexdigest()
+        return f"sha1:{digest}"
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        # Evernote uses YYYYMMDDTHHMMSSZ
+        if re.fullmatch(r"\d{8}T\d{6}Z", value):
+            return datetime.strptime(value, "%Y%m%dT%H%M%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        return dateparser.parse(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _text(elem: etree._Element | None) -> str | None:
+    if elem is None:
+        return None
+    if elem.text is None:
+        return None
+    text = elem.text.strip()
+    return text or None
+
+
+def _extract_guid(
+    source_url: str | None,
+    application_data: dict[str, str],
+) -> tuple[str | None, str]:
+    """Return (guid, source_label)."""
+    if source_url:
+        match = EVERNOTE_URL_GUID_RE.search(source_url)
+        if match:
+            return match.group(1).lower(), "source-url"
+
+    for key in ("evernote.guid", "guid", "noteGuid"):
+        if key in application_data:
+            value = application_data[key].strip()
+            if value:
+                return value.lower(), f"application-data[{key}]"
+
+    return None, "missing"
+
+
+def _parse_note(elem: etree._Element) -> Note:
+    title = _text(elem.find("title")) or "(untitled)"
+    content = elem.findtext("content") or ""
+    created = _parse_datetime(_text(elem.find("created")))
+    updated = _parse_datetime(_text(elem.find("updated")))
+    tags = [t.text.strip() for t in elem.findall("tag") if t.text and t.text.strip()]
+
+    raw_attributes: dict[str, str] = {}
+    application_data: dict[str, str] = {}
+    attrs = elem.find("note-attributes")
+    if attrs is not None:
+        for child in attrs:
+            tag = etree.QName(child).localname
+            if tag == "application-data":
+                key = child.get("key") or ""
+                if key:
+                    application_data[key] = (child.text or "").strip()
+                continue
+            if child.text is not None:
+                raw_attributes[tag] = child.text.strip()
+
+    def _attr(name: str) -> str | None:
+        value = raw_attributes.get(name)
+        return value if value else None
+
+    def _attr_float(name: str) -> float | None:
+        value = _attr(name)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            return None
+
+    source_url = _attr("source-url")
+    guid, guid_source = _extract_guid(source_url, application_data)
+
+    resources: list[Resource] = []
+    for res in elem.findall("resource"):
+        mime = _text(res.find("mime"))
+        size = res.findtext("data/@size") if False else None
+        data_elem = res.find("data")
+        if data_elem is not None:
+            size_attr = data_elem.get("size")
+            if size_attr:
+                try:
+                    size = int(size_attr)
+                except ValueError:
+                    size = None
+        rattrs = res.find("resource-attributes")
+        filename = _text(rattrs.find("file-name")) if rattrs is not None else None
+        hash_md5 = _text(rattrs.find("hash")) if rattrs is not None else None
+        resources.append(
+            Resource(mime=mime, filename=filename, hash_md5=hash_md5, size=size)
+        )
+
+    return Note(
+        title=title,
+        content_enml=content,
+        created=created,
+        updated=updated,
+        tags=tags,
+        source_url=source_url,
+        source=_attr("source"),
+        source_application=_attr("source-application"),
+        author=_attr("author"),
+        reminder_time=_parse_datetime(_attr("reminder-time")),
+        reminder_done_time=_parse_datetime(_attr("reminder-done-time")),
+        latitude=_attr_float("latitude"),
+        longitude=_attr_float("longitude"),
+        altitude=_attr_float("altitude"),
+        evernote_guid=guid,
+        evernote_guid_source=guid_source,
+        application_data=application_data,
+        resources=resources,
+        raw_attributes=raw_attributes,
+    )
+
+
+def parse_enex(path: str | Path) -> Iterator[Note]:
+    """Yield Notes from an .enex file. Streams the file to keep memory low."""
+    path = Path(path)
+    context = etree.iterparse(
+        str(path),
+        events=("end",),
+        tag="note",
+        huge_tree=True,
+        resolve_entities=False,
+    )
+    for _, elem in context:
+        try:
+            yield _parse_note(elem)
+        finally:
+            elem.clear()
+            # Free siblings already processed.
+            while elem.getprevious() is not None:
+                del elem.getparent()[0]

--- a/evernote-2026-05-01/enml_converter.py
+++ b/evernote-2026-05-01/enml_converter.py
@@ -1,0 +1,298 @@
+"""Convert ENML (Evernote's HTML dialect) into Notion block payloads.
+
+Notion has tight limits we have to honour:
+
+* Each rich-text item caps at 2000 characters.
+* A single ``children`` array on page creation caps at 100 blocks; longer
+  documents need ``blocks.children.append`` follow-ups.
+
+This converter focuses on the high-frequency tags that real notes use. Tags it
+does not recognise are flattened into plain text rather than dropped, so no
+content is silently lost. Embedded resources (``<en-media>``) are emitted as
+callout blocks describing the missing attachment, since uploading binary data
+to Notion requires an external host.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+
+
+NOTION_TEXT_LIMIT = 2000
+
+
+def enml_to_blocks(enml: str) -> list[dict]:
+    """Parse an ENML string and return a list of Notion block dicts."""
+    if not enml or not enml.strip():
+        return []
+
+    soup = BeautifulSoup(enml, "lxml-xml")
+    root = soup.find("en-note")
+    if root is None:
+        # Some ENEX files store HTML without the wrapper; fall back to lxml HTML.
+        soup = BeautifulSoup(enml, "lxml")
+        root = soup.body or soup
+
+    blocks: list[dict] = []
+    for child in root.children:
+        blocks.extend(_node_to_blocks(child))
+    return _coalesce_empty(blocks)
+
+
+def _coalesce_empty(blocks: list[dict]) -> list[dict]:
+    """Drop empty paragraphs that appear back-to-back."""
+    out: list[dict] = []
+    last_empty = False
+    for block in blocks:
+        is_empty = (
+            block.get("type") == "paragraph"
+            and not block["paragraph"].get("rich_text")
+        )
+        if is_empty and last_empty:
+            continue
+        out.append(block)
+        last_empty = is_empty
+    return out
+
+
+def _node_to_blocks(node) -> list[dict]:
+    if isinstance(node, NavigableString):
+        text = str(node)
+        if not text.strip():
+            return []
+        return [_paragraph(_text_to_rich(text))]
+
+    if not isinstance(node, Tag):
+        return []
+
+    name = node.name.lower() if node.name else ""
+
+    if name in {"h1", "h2", "h3"}:
+        rich = list(_inline_rich_text(node))
+        return [_heading(name, rich)]
+
+    if name in {"h4", "h5", "h6"}:
+        # Notion only supports h1-h3; demote to h3 with bold.
+        rich = list(_inline_rich_text(node))
+        for r in rich:
+            r["annotations"]["bold"] = True
+        return [_heading("h3", rich)]
+
+    if name in {"p", "div"}:
+        # If the div only contains block-level children, descend.
+        if _has_block_children(node):
+            out: list[dict] = []
+            for child in node.children:
+                out.extend(_node_to_blocks(child))
+            return out
+        rich = list(_inline_rich_text(node))
+        return [_paragraph(rich)]
+
+    if name == "ul":
+        return [_list_item("bulleted_list_item", li) for li in node.find_all("li", recursive=False)]
+
+    if name == "ol":
+        return [_list_item("numbered_list_item", li) for li in node.find_all("li", recursive=False)]
+
+    if name == "li":
+        return [_list_item("bulleted_list_item", node)]
+
+    if name == "blockquote":
+        rich = list(_inline_rich_text(node))
+        return [{"object": "block", "type": "quote", "quote": {"rich_text": rich}}]
+
+    if name in {"pre", "code"}:
+        rich = [{
+            "type": "text",
+            "text": {"content": chunk},
+            "annotations": _default_annotations(),
+        } for chunk in _chunk_text(node.get_text())]
+        return [{
+            "object": "block",
+            "type": "code",
+            "code": {"rich_text": rich, "language": "plain text"},
+        }]
+
+    if name == "hr":
+        return [{"object": "block", "type": "divider", "divider": {}}]
+
+    if name == "br":
+        return []
+
+    if name == "table":
+        # Notion table blocks require careful structure; fall back to text.
+        rows = []
+        for tr in node.find_all("tr"):
+            cells = [c.get_text(" ", strip=True) for c in tr.find_all(["td", "th"])]
+            rows.append(" | ".join(cells))
+        text = "\n".join(rows)
+        return [_paragraph(_text_to_rich(text))]
+
+    if name == "en-media":
+        mime = node.get("type", "unknown")
+        hash_md5 = node.get("hash", "")
+        return [{
+            "object": "block",
+            "type": "callout",
+            "callout": {
+                "icon": {"type": "emoji", "emoji": "📎"},
+                "rich_text": _text_to_rich(
+                    f"[Evernote attachment: {mime} hash={hash_md5}]"
+                ),
+            },
+        }]
+
+    if name == "en-todo":
+        checked = node.get("checked", "false").lower() == "true"
+        return [{
+            "object": "block",
+            "type": "to_do",
+            "to_do": {
+                "rich_text": list(_inline_rich_text(node)),
+                "checked": checked,
+            },
+        }]
+
+    if name in {"img"}:
+        src = node.get("src")
+        if src and src.startswith(("http://", "https://")):
+            return [{
+                "object": "block",
+                "type": "image",
+                "image": {"type": "external", "external": {"url": src}},
+            }]
+        return [_paragraph(_text_to_rich(f"[image: {src or 'embedded'}]"))]
+
+    # Unknown tag - flatten inline.
+    rich = list(_inline_rich_text(node))
+    if rich:
+        return [_paragraph(rich)]
+    return []
+
+
+def _has_block_children(node: Tag) -> bool:
+    block_tags = {
+        "p", "div", "ul", "ol", "li", "blockquote", "pre", "h1", "h2", "h3",
+        "h4", "h5", "h6", "hr", "table",
+    }
+    return any(
+        isinstance(c, Tag) and c.name and c.name.lower() in block_tags
+        for c in node.children
+    )
+
+
+def _list_item(block_type: str, li: Tag) -> dict:
+    rich = list(_inline_rich_text(li))
+    return {
+        "object": "block",
+        "type": block_type,
+        block_type: {"rich_text": rich},
+    }
+
+
+def _heading(name: str, rich: list[dict]) -> dict:
+    block_type = {"h1": "heading_1", "h2": "heading_2", "h3": "heading_3"}[name]
+    return {
+        "object": "block",
+        "type": block_type,
+        block_type: {"rich_text": rich},
+    }
+
+
+def _paragraph(rich: list[dict]) -> dict:
+    return {
+        "object": "block",
+        "type": "paragraph",
+        "paragraph": {"rich_text": rich},
+    }
+
+
+def _default_annotations() -> dict:
+    return {
+        "bold": False,
+        "italic": False,
+        "underline": False,
+        "strikethrough": False,
+        "code": False,
+    }
+
+
+def _chunk_text(text: str) -> list[str]:
+    if len(text) <= NOTION_TEXT_LIMIT:
+        return [text]
+    return [
+        text[i : i + NOTION_TEXT_LIMIT]
+        for i in range(0, len(text), NOTION_TEXT_LIMIT)
+    ]
+
+
+def _text_to_rich(
+    text: str,
+    annotations: dict | None = None,
+    link: str | None = None,
+) -> list[dict]:
+    annotations = annotations or _default_annotations()
+    rich: list[dict] = []
+    for chunk in _chunk_text(text):
+        item = {
+            "type": "text",
+            "text": {"content": chunk},
+            "annotations": dict(annotations),
+        }
+        if link:
+            item["text"]["link"] = {"url": link}
+        rich.append(item)
+    return rich
+
+
+_INLINE_STYLE_TAGS = {
+    "b": {"bold": True},
+    "strong": {"bold": True},
+    "i": {"italic": True},
+    "em": {"italic": True},
+    "u": {"underline": True},
+    "s": {"strikethrough": True},
+    "strike": {"strikethrough": True},
+    "del": {"strikethrough": True},
+    "code": {"code": True},
+    "tt": {"code": True},
+}
+
+
+def _inline_rich_text(
+    node: Tag,
+    annotations: dict | None = None,
+    link: str | None = None,
+) -> Iterable[dict]:
+    annotations = annotations if annotations is not None else _default_annotations()
+    for child in node.children:
+        if isinstance(child, NavigableString):
+            text = str(child)
+            if text:
+                yield from _text_to_rich(text, annotations, link)
+            continue
+        if not isinstance(child, Tag):
+            continue
+        name = (child.name or "").lower()
+        if name == "br":
+            yield from _text_to_rich("\n", annotations, link)
+            continue
+        if name == "a":
+            yield from _inline_rich_text(child, annotations, child.get("href") or link)
+            continue
+        if name in _INLINE_STYLE_TAGS:
+            new_annotations = dict(annotations)
+            new_annotations.update(_INLINE_STYLE_TAGS[name])
+            yield from _inline_rich_text(child, new_annotations, link)
+            continue
+        if name == "en-media":
+            mime = child.get("type", "unknown")
+            hash_md5 = child.get("hash", "")
+            yield from _text_to_rich(
+                f"[attachment {mime} {hash_md5}]", annotations, link
+            )
+            continue
+        # Default: descend, preserving annotations.
+        yield from _inline_rich_text(child, annotations, link)

--- a/evernote-2026-05-01/migrate.py
+++ b/evernote-2026-05-01/migrate.py
@@ -1,0 +1,162 @@
+"""CLI entry point: migrate one or more .enex files into a Notion database."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from enex_parser import parse_enex
+from notion_migrator import NotionMigrator
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Migrate Evernote .enex files into a Notion database, "
+        "preserving the original Evernote GUID and metadata as columns.",
+    )
+    parser.add_argument(
+        "enex_files",
+        nargs="+",
+        type=Path,
+        help="One or more Evernote .enex export files.",
+    )
+    parser.add_argument(
+        "--database-title",
+        default="Evernote Migration",
+        help="Title used when creating a new Notion database.",
+    )
+    parser.add_argument(
+        "--no-skip-existing",
+        action="store_true",
+        help="Re-migrate notes even if a row with the same Evernote GUID exists.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse the .enex file(s) without calling Notion. Useful for inspecting "
+        "what GUIDs the parser would store.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Process at most N notes (per file). Helpful for smoke tests.",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Verbose logging."
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    load_dotenv()
+
+    if args.dry_run:
+        return _run_dry(args)
+
+    token = os.environ.get("NOTION_TOKEN")
+    if not token:
+        print("NOTION_TOKEN is not set (see .env.example).", file=sys.stderr)
+        return 2
+
+    parent_page_id = os.environ.get("NOTION_PARENT_PAGE_ID")
+    database_id = os.environ.get("NOTION_DATABASE_ID")
+    if not database_id and not parent_page_id:
+        print(
+            "Set NOTION_DATABASE_ID (to reuse a database) or "
+            "NOTION_PARENT_PAGE_ID (to create one).",
+            file=sys.stderr,
+        )
+        return 2
+
+    total_success = 0
+    total_failed = 0
+    total_skipped = 0
+    for enex in args.enex_files:
+        if not enex.exists():
+            print(f"File not found: {enex}", file=sys.stderr)
+            return 2
+        migrator = NotionMigrator(
+            token=token,
+            parent_page_id=parent_page_id,
+            database_id=database_id,
+            database_title=args.database_title,
+            source_file=enex.name,
+            skip_existing=not args.no_skip_existing,
+        )
+        notes_iter = parse_enex(enex)
+        if args.limit is not None:
+            notes_iter = _take(notes_iter, args.limit)
+
+        results = migrator.migrate(notes_iter)
+        # After the first file we always have a database id.
+        database_id = migrator.database_id
+        for r in results:
+            if r.status == "Success":
+                total_success += 1
+            elif r.status == "Skipped":
+                total_skipped += 1
+            else:
+                total_failed += 1
+                print(
+                    f"[{r.status}] {r.note.title} ({r.note.stable_id}): {r.error}",
+                    file=sys.stderr,
+                )
+
+    print(
+        f"Done. success={total_success} skipped={total_skipped} failed={total_failed} "
+        f"database_id={database_id}"
+    )
+    return 0 if total_failed == 0 else 1
+
+
+def _run_dry(args: argparse.Namespace) -> int:
+    for enex in args.enex_files:
+        if not enex.exists():
+            print(f"File not found: {enex}", file=sys.stderr)
+            return 2
+        notes_iter = parse_enex(enex)
+        if args.limit is not None:
+            notes_iter = _take(notes_iter, args.limit)
+        for note in notes_iter:
+            payload = {
+                "title": note.title,
+                "evernote_guid": note.evernote_guid,
+                "stable_id": note.stable_id,
+                "guid_source": note.evernote_guid_source,
+                "created": note.created.isoformat() if note.created else None,
+                "updated": note.updated.isoformat() if note.updated else None,
+                "tags": note.tags,
+                "source_url": note.source_url,
+                "author": note.author,
+                "source_application": note.source_application,
+                "resources": [
+                    {"mime": r.mime, "filename": r.filename, "size": r.size}
+                    for r in note.resources
+                ],
+            }
+            print(json.dumps(payload, ensure_ascii=False))
+    return 0
+
+
+def _take(iterable, limit):
+    for i, item in enumerate(iterable):
+        if i >= limit:
+            break
+        yield item
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evernote-2026-05-01/mise.toml
+++ b/evernote-2026-05-01/mise.toml
@@ -1,0 +1,14 @@
+[tools]
+uv = "0.7.20"
+
+[tasks.migrate]
+description = "Migrate notes from an .enex file into Notion."
+run = '''
+uv run python migrate.py "$@"
+'''
+
+[tasks.test]
+description = "Run unit tests."
+run = '''
+uv run pytest -v
+'''

--- a/evernote-2026-05-01/notion_migrator.py
+++ b/evernote-2026-05-01/notion_migrator.py
@@ -1,0 +1,298 @@
+"""Push parsed Evernote notes into a Notion database.
+
+The database schema deliberately surfaces every Evernote-specific identifier
+the official importer drops:
+
+* ``Evernote GUID`` - canonical identifier (preserved as a column for queries)
+* ``Evernote GUID Source`` - tells you whether the GUID came from a real
+  ``source-url``, an ``application-data`` key, or the SHA-1 fallback
+* ``Source URL`` - raw ``evernote://`` link if any
+* ``Source``, ``Source Application``, ``Author``
+* ``Created`` / ``Updated`` - original Evernote timestamps
+* ``Tags`` - multi-select
+* ``Reminder`` / ``Reminder Done`` - reminders
+* ``Latitude`` / ``Longitude`` / ``Altitude`` - geo
+* ``Source File`` - the .enex file the note came from
+* ``Migrated At`` - when this row was written
+* ``Migration Status`` - Success / Partial / Failed
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from notion_client import Client
+from notion_client.errors import APIResponseError
+
+from enex_parser import Note
+from enml_converter import enml_to_blocks
+
+
+log = logging.getLogger(__name__)
+
+DATABASE_TITLE_DEFAULT = "Evernote Migration"
+NOTION_BLOCK_BATCH = 100
+
+
+@dataclass
+class MigrationResult:
+    note: Note
+    page_id: str | None
+    status: str  # Success | Partial | Failed | Skipped
+    error: str | None = None
+
+
+class NotionMigrator:
+    def __init__(
+        self,
+        token: str,
+        *,
+        parent_page_id: str | None = None,
+        database_id: str | None = None,
+        database_title: str = DATABASE_TITLE_DEFAULT,
+        source_file: str | Path | None = None,
+        skip_existing: bool = True,
+    ) -> None:
+        if not database_id and not parent_page_id:
+            raise ValueError(
+                "Either database_id or parent_page_id must be provided."
+            )
+        self.client = Client(auth=token)
+        self.parent_page_id = parent_page_id
+        self.database_id = database_id
+        self.database_title = database_title
+        self.source_file = str(source_file) if source_file else ""
+        self.skip_existing = skip_existing
+
+    # ------------------------------------------------------------------ database
+
+    def ensure_database(self) -> str:
+        if self.database_id:
+            return self.database_id
+        log.info("Creating Notion database under page %s", self.parent_page_id)
+        response = self.client.databases.create(
+            parent={"type": "page_id", "page_id": self.parent_page_id},
+            title=[{"type": "text", "text": {"content": self.database_title}}],
+            properties=self._database_properties(),
+        )
+        self.database_id = response["id"]
+        log.info("Created database %s", self.database_id)
+        return self.database_id
+
+    @staticmethod
+    def _database_properties() -> dict:
+        return {
+            "Title": {"title": {}},
+            "Evernote GUID": {"rich_text": {}},
+            "Evernote GUID Source": {
+                "select": {
+                    "options": [
+                        {"name": "source-url", "color": "green"},
+                        {"name": "application-data", "color": "blue"},
+                        {"name": "sha1-fallback", "color": "yellow"},
+                        {"name": "missing", "color": "red"},
+                    ]
+                }
+            },
+            "Source URL": {"url": {}},
+            "Source": {"rich_text": {}},
+            "Source Application": {"rich_text": {}},
+            "Author": {"rich_text": {}},
+            "Created": {"date": {}},
+            "Updated": {"date": {}},
+            "Tags": {"multi_select": {}},
+            "Reminder": {"date": {}},
+            "Reminder Done": {"date": {}},
+            "Latitude": {"number": {"format": "number"}},
+            "Longitude": {"number": {"format": "number"}},
+            "Altitude": {"number": {"format": "number"}},
+            "Source File": {"rich_text": {}},
+            "Migrated At": {"date": {}},
+            "Migration Status": {
+                "select": {
+                    "options": [
+                        {"name": "Success", "color": "green"},
+                        {"name": "Partial", "color": "yellow"},
+                        {"name": "Failed", "color": "red"},
+                    ]
+                }
+            },
+        }
+
+    # --------------------------------------------------------------- migration
+
+    def migrate(self, notes: Iterable[Note]) -> list[MigrationResult]:
+        self.ensure_database()
+        results: list[MigrationResult] = []
+        for note in notes:
+            results.append(self.migrate_note(note))
+        return results
+
+    def migrate_note(self, note: Note) -> MigrationResult:
+        if self.skip_existing:
+            existing = self.find_existing_page(note.stable_id)
+            if existing:
+                log.info("Skipping existing note %s -> %s", note.title, existing)
+                return MigrationResult(note, existing, "Skipped")
+
+        blocks = enml_to_blocks(note.content_enml)
+        first_batch = blocks[:NOTION_BLOCK_BATCH]
+        rest = blocks[NOTION_BLOCK_BATCH:]
+        properties = self._note_properties(note)
+
+        try:
+            page = self._with_retry(
+                self.client.pages.create,
+                parent={"database_id": self.database_id},
+                properties=properties,
+                children=first_batch,
+            )
+        except APIResponseError as exc:
+            log.error("Failed to create page for %s: %s", note.title, exc)
+            return MigrationResult(note, None, "Failed", str(exc))
+
+        page_id = page["id"]
+        partial = False
+        for i in range(0, len(rest), NOTION_BLOCK_BATCH):
+            chunk = rest[i : i + NOTION_BLOCK_BATCH]
+            try:
+                self._with_retry(
+                    self.client.blocks.children.append,
+                    block_id=page_id,
+                    children=chunk,
+                )
+            except APIResponseError as exc:
+                log.warning("Failed to append blocks to %s: %s", page_id, exc)
+                partial = True
+                break
+
+        status = "Partial" if partial else "Success"
+        if status == "Partial":
+            self._safe_update_status(page_id, status)
+        return MigrationResult(note, page_id, status)
+
+    # -------------------------------------------------------------- properties
+
+    def _note_properties(self, note: Note) -> dict:
+        guid_source_label = (
+            "sha1-fallback"
+            if note.evernote_guid is None
+            else (
+                "source-url"
+                if note.evernote_guid_source == "source-url"
+                else "application-data"
+            )
+        )
+        properties = {
+            "Title": _title(note.title),
+            "Evernote GUID": _rich_text(note.stable_id),
+            "Evernote GUID Source": _select(guid_source_label),
+            "Tags": {
+                "multi_select": [{"name": _safe_select_name(t)} for t in note.tags]
+            },
+            "Source File": _rich_text(self.source_file),
+            "Migrated At": _date(datetime.now(timezone.utc)),
+            "Migration Status": _select("Success"),
+        }
+        if note.source_url:
+            properties["Source URL"] = {"url": note.source_url}
+        if note.source:
+            properties["Source"] = _rich_text(note.source)
+        if note.source_application:
+            properties["Source Application"] = _rich_text(note.source_application)
+        if note.author:
+            properties["Author"] = _rich_text(note.author)
+        if note.created:
+            properties["Created"] = _date(note.created)
+        if note.updated:
+            properties["Updated"] = _date(note.updated)
+        if note.reminder_time:
+            properties["Reminder"] = _date(note.reminder_time)
+        if note.reminder_done_time:
+            properties["Reminder Done"] = _date(note.reminder_done_time)
+        if note.latitude is not None:
+            properties["Latitude"] = {"number": note.latitude}
+        if note.longitude is not None:
+            properties["Longitude"] = {"number": note.longitude}
+        if note.altitude is not None:
+            properties["Altitude"] = {"number": note.altitude}
+        return properties
+
+    def _safe_update_status(self, page_id: str, status: str) -> None:
+        try:
+            self.client.pages.update(
+                page_id=page_id,
+                properties={"Migration Status": _select(status)},
+            )
+        except APIResponseError:
+            pass
+
+    # --------------------------------------------------------------- queries
+
+    def find_existing_page(self, evernote_id: str) -> str | None:
+        try:
+            response = self.client.databases.query(
+                database_id=self.database_id,
+                filter={
+                    "property": "Evernote GUID",
+                    "rich_text": {"equals": evernote_id},
+                },
+                page_size=1,
+            )
+        except APIResponseError as exc:
+            log.warning("Query failed when checking for duplicate %s: %s", evernote_id, exc)
+            return None
+        results = response.get("results", [])
+        return results[0]["id"] if results else None
+
+    # ----------------------------------------------------------------- retry
+
+    @staticmethod
+    def _with_retry(func, *args, max_attempts: int = 4, **kwargs):
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return func(*args, **kwargs)
+            except APIResponseError as exc:
+                status = getattr(exc, "status", None)
+                if status in {429, 500, 502, 503, 504} and attempt < max_attempts:
+                    log.warning(
+                        "Notion API %s, retrying in %.1fs (attempt %d/%d)",
+                        status, delay, attempt, max_attempts,
+                    )
+                    time.sleep(delay)
+                    delay *= 2
+                    continue
+                raise
+
+
+# --------------------------------------------------------------------- helpers
+
+
+def _title(text: str) -> dict:
+    return {"title": [{"type": "text", "text": {"content": text[:2000]}}]}
+
+
+def _rich_text(text: str) -> dict:
+    return {
+        "rich_text": [{"type": "text", "text": {"content": (text or "")[:2000]}}]
+    }
+
+
+def _date(value: datetime) -> dict:
+    return {"date": {"start": value.isoformat()}}
+
+
+def _select(name: str) -> dict:
+    return {"select": {"name": name}}
+
+
+def _safe_select_name(name: str) -> str:
+    # Notion rejects commas in select names.
+    cleaned = name.replace(",", " ").strip()
+    return cleaned[:100] or "untagged"

--- a/evernote-2026-05-01/pyproject.toml
+++ b/evernote-2026-05-01/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "evernote-notion-migration"
+version = "0.1.0"
+description = "Migrate Evernote (.enex) notes into a Notion database, preserving the original Evernote GUID and metadata as database columns."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "notion-client>=2.2.1",
+    "beautifulsoup4>=4.12.0",
+    "lxml>=5.0.0",
+    "python-dateutil>=2.9.0",
+    "python-dotenv>=1.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/evernote-2026-05-01/tests/sample.enex
+++ b/evernote-2026-05-01/tests/sample.enex
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20260501T120000Z" application="Evernote" version="10.0">
+  <note>
+    <title>Hello Notion</title>
+    <created>20240115T101530Z</created>
+    <updated>20240210T091200Z</updated>
+    <tag>migration</tag>
+    <tag>demo</tag>
+    <note-attributes>
+      <author>jane@example.com</author>
+      <source>desktop.mac</source>
+      <source-application>evernote.mac</source-application>
+      <source-url>evernote:///view/12345/s10/abcdef12-3456-7890-abcd-ef1234567890/abcdef12-3456-7890-abcd-ef1234567890/</source-url>
+      <latitude>35.6812</latitude>
+      <longitude>139.7671</longitude>
+    </note-attributes>
+    <content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+<en-note>
+  <h1>Hello</h1>
+  <p>This is a <b>bold</b> and <i>italic</i> note with a <a href="https://www.notion.so">link</a>.</p>
+  <ul>
+    <li>first</li>
+    <li>second</li>
+  </ul>
+  <en-todo checked="true"/>done item
+  <en-todo checked="false"/>todo item
+  <pre>code block</pre>
+</en-note>
+]]></content>
+  </note>
+  <note>
+    <title>No GUID note</title>
+    <created>20240301T000000Z</created>
+    <updated>20240301T000000Z</updated>
+    <note-attributes>
+      <author>anon</author>
+    </note-attributes>
+    <content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+<en-note><p>Plain note without source URL.</p></en-note>
+]]></content>
+  </note>
+  <note>
+    <title>GUID via application-data</title>
+    <created>20240401T120000Z</created>
+    <updated>20240401T120000Z</updated>
+    <note-attributes>
+      <author>anon</author>
+      <application-data key="evernote.guid">deadbeef-dead-beef-dead-beefdeadbeef</application-data>
+    </note-attributes>
+    <content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+<en-note><p>application-data path</p></en-note>
+]]></content>
+  </note>
+</en-export>

--- a/evernote-2026-05-01/tests/test_enex_parser.py
+++ b/evernote-2026-05-01/tests/test_enex_parser.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from enex_parser import parse_enex
+
+
+SAMPLE = Path(__file__).parent / "sample.enex"
+
+
+def test_parses_all_notes():
+    notes = list(parse_enex(SAMPLE))
+    assert len(notes) == 3
+    assert [n.title for n in notes] == [
+        "Hello Notion",
+        "No GUID note",
+        "GUID via application-data",
+    ]
+
+
+def test_extracts_guid_from_source_url():
+    notes = list(parse_enex(SAMPLE))
+    n = notes[0]
+    assert n.evernote_guid == "abcdef12-3456-7890-abcd-ef1234567890"
+    assert n.evernote_guid_source == "source-url"
+    assert n.stable_id == n.evernote_guid
+
+
+def test_extracts_guid_from_application_data():
+    notes = list(parse_enex(SAMPLE))
+    n = notes[2]
+    assert n.evernote_guid == "deadbeef-dead-beef-dead-beefdeadbeef"
+    assert n.evernote_guid_source == "application-data[evernote.guid]"
+
+
+def test_falls_back_to_stable_hash():
+    notes = list(parse_enex(SAMPLE))
+    n = notes[1]
+    assert n.evernote_guid is None
+    assert n.evernote_guid_source == "missing"
+    assert n.stable_id.startswith("sha1:")
+    # Stable across re-parses.
+    again = list(parse_enex(SAMPLE))[1]
+    assert n.stable_id == again.stable_id
+
+
+def test_parses_metadata():
+    n = list(parse_enex(SAMPLE))[0]
+    assert n.created == datetime(2024, 1, 15, 10, 15, 30, tzinfo=timezone.utc)
+    assert n.updated == datetime(2024, 2, 10, 9, 12, 0, tzinfo=timezone.utc)
+    assert n.author == "jane@example.com"
+    assert n.source == "desktop.mac"
+    assert n.source_application == "evernote.mac"
+    assert n.tags == ["migration", "demo"]
+    assert n.latitude == 35.6812
+    assert n.longitude == 139.7671

--- a/evernote-2026-05-01/tests/test_enml_converter.py
+++ b/evernote-2026-05-01/tests/test_enml_converter.py
@@ -1,0 +1,59 @@
+from enml_converter import enml_to_blocks
+
+
+SIMPLE = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+<en-note>
+  <h1>Title</h1>
+  <p>Hello <b>world</b> with <a href="https://example.com">link</a>.</p>
+  <ul>
+    <li>one</li>
+    <li>two</li>
+  </ul>
+  <en-todo checked="true"/>finished
+  <pre>code</pre>
+</en-note>
+"""
+
+
+def _types(blocks):
+    return [b["type"] for b in blocks]
+
+
+def test_basic_block_types():
+    blocks = enml_to_blocks(SIMPLE)
+    types = _types(blocks)
+    assert "heading_1" in types
+    assert "paragraph" in types
+    assert types.count("bulleted_list_item") == 2
+    assert "code" in types
+
+
+def test_link_and_bold_annotations():
+    blocks = enml_to_blocks(SIMPLE)
+    paragraph = next(b for b in blocks if b["type"] == "paragraph")
+    rich = paragraph["paragraph"]["rich_text"]
+    assert any(r["annotations"]["bold"] for r in rich), rich
+    assert any(
+        r.get("text", {}).get("link", {}).get("url") == "https://example.com"
+        for r in rich
+    ), rich
+
+
+def test_long_text_chunks():
+    long_text = "x" * 5000
+    enml = (
+        '<?xml version="1.0" encoding="UTF-8"?><en-note><p>'
+        + long_text
+        + "</p></en-note>"
+    )
+    blocks = enml_to_blocks(enml)
+    paragraph = blocks[0]
+    rich = paragraph["paragraph"]["rich_text"]
+    assert all(len(r["text"]["content"]) <= 2000 for r in rich)
+    assert sum(len(r["text"]["content"]) for r in rich) == 5000
+
+
+def test_empty_input_returns_empty():
+    assert enml_to_blocks("") == []
+    assert enml_to_blocks("   ") == []

--- a/evernote-2026-05-01/uv.lock
+++ b/evernote-2026-05-01/uv.lock
@@ -1,0 +1,314 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "evernote-notion-migration"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "lxml" },
+    { name = "notion-client" },
+    { name = "python-dateutil" },
+    { name = "python-dotenv" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "lxml", specifier = ">=5.0.0" },
+    { name = "notion-client", specifier = ">=2.2.1" },
+    { name = "python-dateutil", specifier = ">=2.9.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+]
+
+[[package]]
+name = "notion-client"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/39/60afcbc0148c3dafaaefe851ae3f058077db49d66288dfb218a11a57b997/notion_client-3.0.0.tar.gz", hash = "sha256:05c4d2b4fa3491dc0de21c9c826277202ea8b8714077ee7f51a6e1a09ab23d0f", size = 31357, upload-time = "2026-02-16T11:15:48.024Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/ce/6b03f9aedd2edfcc28e23ced5c2582d543f6ddbb2be5c570533f02890b27/notion_client-3.0.0-py2.py3-none-any.whl", hash = "sha256:177fc3d2ace7e8ef69cf96f46269e8a66071c2c7c526194bf06ce7925853e759", size = 18746, upload-time = "2026-02-16T11:15:46.602Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
Migrates .enex notes into a Notion database while preserving the
original Evernote GUID and metadata as dedicated database columns -
something the official Notion importer drops.

GUID is recovered from the source-url evernote:// link, from
application-data keys, or as a deterministic SHA-1 fallback so every
note has a stable, replayable identifier for de-duplication on re-runs.