### PR TITLE
Proposal: terraform apply patterns from GitHub

### DIFF
--- a/terraform-github-apply-2026-05-02/README.md
+++ b/terraform-github-apply-2026-05-02/README.md
@@ -1,0 +1,176 @@
+# Terraform を GitHub から apply するためのアイディア集
+
+GitHub から `terraform apply` を実行するための代表的なパターンと、それぞれのトレードオフを整理する。
+最終的にどれを選ぶかは「**誰が／どのタイミングで／どのクラウドに対して**」適用するかで決まる。
+
+---
+
+## TL;DR (推奨パターン)
+
+> **GitHub Actions + OIDC + GitHub Environments + PR-driven workflow**
+>
+> - Pull Request で `terraform plan` を自動実行し、結果を PR コメントへ
+> - `main` にマージされたら `terraform apply` を実行 (本番は Environment の Required reviewer で承認ゲート)
+> - クラウド資格情報は OIDC で短期トークン化 (GitHub Secrets に長寿命キーを置かない)
+> - State は S3 / GCS / Azure Blob などのリモートバックエンド + ロック機構
+
+このパターンは `examples/01-actions-oidc-aws/` および `examples/02-actions-oidc-gcp/` にサンプルあり。
+
+---
+
+## パターン比較
+
+| # | パターン | 実行場所 | 認証 | 承認 UI | コスト | 向いている規模 |
+|---|---|---|---|---|---|---|
+| 1 | GitHub Actions + OIDC | GH ホストランナー | OIDC → IAM Role | Environments / PR review | 無料枠あり | 小〜中 |
+| 2 | Atlantis (self-hosted) | 自前 EC2/ECS/K8s | IAM Role / SA | PR コメント `atlantis apply` | 自前ホスト代 | 中〜大 |
+| 3 | Terraform Cloud / HCP Terraform | TFC 上 | TFC Workspace 設定 | TFC UI で承認 | 有料 (無料枠あり) | 中〜大 |
+| 4 | Spacelift / env0 / Scalr | SaaS | SaaS 統合 | SaaS UI | 有料 | 中〜大 |
+| 5 | Self-hosted Runner | 自 VPC 内ランナー | インスタンスロール | Environments | ランナー代 | プライベート network 必須時 |
+| 6 | workflow_dispatch (手動) | GH ホストランナー | OIDC | UI で `Run workflow` | 無料 | PoC / 緊急時 |
+
+---
+
+## 1. GitHub Actions + OIDC (推奨)
+
+### 仕組み
+
+```
+PR open ──▶ terraform plan ──▶ PR にコメント
+                │
+merge to main ──▶ terraform apply (Environment 承認)
+                │
+                ▼
+          OIDC token ──▶ AWS STS AssumeRoleWithWebIdentity
+                       └▶ GCP Workload Identity Federation
+                       └▶ Azure Federated Credential
+```
+
+### メリット
+
+- 長寿命のクラウド資格情報を GitHub Secrets に保存しない
+- `permissions: id-token: write` だけで OIDC が使える
+- PR ベースの GitOps が自然に組める
+- GitHub Environments で本番のみ手動承認・必須レビュアーを設定できる
+
+### デメリット
+
+- GH ホストランナーはパブリック egress なので、プライベートネットワーク内のリソースに直接到達できない場合は `5. Self-hosted Runner` を併用
+- 並列実行で state ロックがぶつかるので必ずリモートバックエンド + ロックを使うこと
+- GitHub Actions の concurrency 制御も併用するのが安全
+
+### キーポイント
+
+```yaml
+# 同じ environment への apply は直列化
+concurrency:
+  group: tf-apply-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write   # OIDC
+  contents: read
+  pull-requests: write   # plan 結果を PR にコメント
+```
+
+---
+
+## 2. Atlantis (self-hosted)
+
+PR で `atlantis plan` / `atlantis apply` のコメントをトリガにして apply するワーカ。
+
+### メリット
+
+- PR コメントで承認・適用のフローが完結 (plan 出力もコメントで確認しやすい)
+- 大量の workspace / 複数の repo を集中管理できる
+- 自前ホストなので、プライベートネットワーク内クラスタの apply も可能
+
+### デメリット
+
+- Atlantis サーバ自身の運用コスト (EKS / ECS / Fargate 上で動かすことが多い)
+- Webhook を受けるエンドポイントを公開するか、GitHub App で pull 型にする必要がある
+- 承認ポリシー (apply 権限のあるユーザ) の設計が必要
+
+詳細サンプル: `examples/03-atlantis/`
+
+---
+
+## 3. Terraform Cloud / HCP Terraform (VCS-driven)
+
+TFC の Workspace を GitHub repo にひも付けると、push / PR で plan が走り、TFC UI から apply する。
+
+### メリット
+
+- State 管理・ロック・履歴・Sentinel ポリシーが統合
+- apply の承認 UI が TFC 側にある
+- Run task 経由で TFLint / Checkov / Trivy を組み込める
+
+### デメリット
+
+- 月額費用 (人数 / Workspace 数で課金)
+- TFC が SPOF
+- カスタムが必要なときは GH Actions + tfc CLI のハイブリッドが必要
+
+詳細サンプル: `examples/04-tfc-vcs/`
+
+---
+
+## 4. Self-hosted Runner
+
+GitHub Actions のジョブを **自分の VPC 内ランナー** で動かすパターン。
+基本ワークフローは 1. と同じだが、ランナーがプライベート subnet にいるので **EKS API server や RDS proxy などプライベートエンドポイントに直接届く**。
+
+### 構成例
+
+- `actions/actions-runner-controller` を EKS にデプロイ
+- ランナー Pod に IRSA (IAM Roles for Service Accounts) を付与 → OIDC 不要にできる
+- `runs-on: [self-hosted, terraform]` でジョブを誘導
+
+詳細サンプル: `examples/05-self-hosted-runner/`
+
+---
+
+## 5. workflow_dispatch (手動トリガ)
+
+`on: workflow_dispatch` + `inputs:` で
+
+- `environment` (dev / stg / prd)
+- `action` (plan / apply / destroy)
+- `target` (`-target=...` 用、緊急時のみ)
+
+を選んで Actions UI から `Run workflow` する。
+**緊急対応・PoC・初期構築** には便利。常用するなら 1. の PR-driven に寄せる。
+
+---
+
+## 設計上の必須チェックリスト
+
+| 項目 | 推奨 |
+|---|---|
+| State backend | S3 + DynamoDB / GCS + native lock / azurerm |
+| 認証 | OIDC + IAM Role (AssumeRoleWithWebIdentity) |
+| 並列制御 | `concurrency.group` + state lock |
+| 承認 | GitHub Environments の Required reviewers |
+| 監査 | apply 結果を Slack / Issue / S3 に記録 |
+| Drift 検知 | 日次 `schedule:` で plan を実行し差分を Issue 起票 |
+| Secrets | `tfvars` を repo にコミットしない、`TF_VAR_*` か SOPS / SSM Parameter Store |
+| 静的解析 | `tflint`, `tfsec` / `trivy config`, `checkov` を plan 前に流す |
+| Plan の保存 | `terraform plan -out=tfplan` を artifact に upload し、apply で同じ plan を使う |
+| 破壊操作 | destroy は別 workflow + 別 environment + 二重承認 |
+
+---
+
+## ディレクトリ構成
+
+```
+terraform-github-apply-2026-05-02/
+├── README.md                       ← この提案書
+├── docs/
+│   └── decision-matrix.md          ← パターン選択フローチャート
+└── examples/
+    ├── 01-actions-oidc-aws/        ← 推奨: AWS + OIDC + PR driven
+    ├── 02-actions-oidc-gcp/        ← 推奨: GCP + WIF + PR driven
+    ├── 03-atlantis/                ← Atlantis サーバ最小構成
+    ├── 04-tfc-vcs/                 ← Terraform Cloud VCS 連携
+    └── 05-self-hosted-runner/      ← VPC 内ランナー
+```

--- a/terraform-github-apply-2026-05-02/docs/decision-matrix.md
+++ b/terraform-github-apply-2026-05-02/docs/decision-matrix.md
@@ -1,0 +1,32 @@
+# 選択フローチャート
+
+```
+Q1. Terraform を実行する対象に「プライベートネットワーク経由でしか到達できないリソース」
+    (private EKS API, internal RDS, on-prem 経由など) があるか?
+   ├── Yes ──▶ Self-hosted Runner (5) を VPC 内に置く
+   │           もしくは Atlantis (2) を VPC 内に立てる
+   └── No  ──▶ Q2 へ
+
+Q2. 月額数万円〜の SaaS コストは許容できるか? (Sentinel / 集中管理が欲しい)
+   ├── Yes ──▶ Terraform Cloud / HCP Terraform (3) または Spacelift / env0
+   └── No  ──▶ Q3 へ
+
+Q3. PR コメントベースで plan / apply を回したいか?
+    (大量の workspace を扱う / SRE 以外も apply するなど)
+   ├── Yes ──▶ Atlantis (2) を自前ホスト
+   └── No  ──▶ GitHub Actions + OIDC (1)  ←★ デフォルト選択
+
+Q4. 緊急時の手動 apply 経路は?
+   └─▶ どのパターンでも workflow_dispatch (6) を別 workflow として用意しておく
+       (本番 environment + 二重承認)
+```
+
+## 規模別のおすすめ
+
+| 規模 | パターン |
+|---|---|
+| 個人 / PoC | GitHub Actions + OIDC (1) |
+| スタートアップ初期 | (1) + drift check schedule |
+| 複数チーム / 複数 repo | Atlantis (2) または TFC (3) |
+| 規制業界 / 監査要件強 | TFC (3) + Sentinel または Spacelift OPA |
+| プライベート network 必須 | Self-hosted Runner (5) または Atlantis (2) on-VPC |

--- a/terraform-github-apply-2026-05-02/examples/01-actions-oidc-aws/.github/workflows/terraform.yml
+++ b/terraform-github-apply-2026-05-02/examples/01-actions-oidc-aws/.github/workflows/terraform.yml
@@ -1,0 +1,134 @@
+name: terraform
+
+on:
+  pull_request:
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform.yml"
+  push:
+    branches: [main]
+    paths:
+      - "terraform/**"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "対象 environment"
+        required: true
+        type: choice
+        options: [dev, stg, prd]
+
+permissions:
+  id-token: write       # OIDC で AWS にトークン交換
+  contents: read
+  pull-requests: write  # plan 結果を PR にコメント
+
+concurrency:
+  group: tf-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TF_VERSION: "1.9.5"
+  AWS_REGION: ap-northeast-1
+  TF_IN_AUTOMATION: "true"
+  TF_INPUT: "0"
+
+jobs:
+  plan:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: dev
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_PLAN_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend-config=backend.dev.hcl
+      - run: terraform validate
+
+      - name: tflint
+        uses: terraform-linters/setup-tflint@v4
+      - run: tflint --recursive
+
+      - name: tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+
+      - name: terraform plan
+        id: plan
+        run: |
+          terraform plan -no-color -out=tfplan -detailed-exitcode \
+            -var-file=dev.tfvars
+        continue-on-error: true
+
+      - name: Upload plan
+        if: steps.plan.outputs.exitcode != '1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan-${{ github.event.pull_request.number }}
+          path: terraform/tfplan
+          retention-days: 7
+
+      - name: Comment plan to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+            const out = execSync(
+              'terraform -chdir=terraform show -no-color tfplan',
+              { encoding: 'utf8' }
+            );
+            const body = `### terraform plan\n\n<details><summary>show</summary>\n\n\`\`\`hcl\n${out.slice(0, 60000)}\n\`\`\`\n\n</details>`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+      - name: Fail on plan error
+        if: steps.plan.outputs.exitcode == '1'
+        run: exit 1
+
+  apply:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: prd     # ← Required reviewers をここで強制
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_APPLY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - run: terraform init -backend-config=backend.prd.hcl
+      - run: terraform apply -auto-approve -var-file=prd.tfvars
+
+      - name: Notify Slack
+        if: always()
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {"text": "terraform apply ${{ job.status }} on prd by ${{ github.actor }} @ ${{ github.sha }}"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/terraform-github-apply-2026-05-02/examples/01-actions-oidc-aws/README.md
+++ b/terraform-github-apply-2026-05-02/examples/01-actions-oidc-aws/README.md
@@ -1,0 +1,64 @@
+# 例 1: GitHub Actions + OIDC (AWS) - 推奨パターン
+
+## 前提
+
+AWS 側に GitHub OIDC IdP を一度だけ作っておく。
+
+```hcl
+# AWS 側 (一度だけ)
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_policy_document" "trust_apply" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      # main への push 時のみ apply role を引けるよう絞る
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:ORG/REPO:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "tf_apply" {
+  name               = "github-actions-tf-apply"
+  assume_role_policy = data.aws_iam_policy_document.trust_apply.json
+}
+```
+
+## ポイント
+
+- **plan role** と **apply role** を分け、PR からは plan role しか引けないようにする
+  (`token.actions.githubusercontent.com:sub` で `pull_request` を許可、apply role は `refs/heads/main` だけに絞る)
+- **GitHub Environments** (`prd`) の Required reviewers で apply 前に人間承認
+- `concurrency.group` で同一 ref への apply が直列化される
+- Plan 結果を PR コメントに貼って差分レビューを GitHub 上で完結
+- `-detailed-exitcode` で「変更なし(0) / 変更あり(2) / エラー(1)」を判定
+- 本気でやるなら plan で生成した `tfplan` を artifact に保存し、apply ジョブで同じ plan を `terraform apply tfplan` で適用するのが厳密 (本サンプルは可読性のため省略)
+
+## ワークフロー
+
+`./.github/workflows/terraform.yml` を参照。
+
+## State backend 例 (`terraform/backend.prd.hcl`)
+
+```hcl
+bucket         = "myorg-tfstate-prd"
+key            = "global/network.tfstate"
+region         = "ap-northeast-1"
+dynamodb_table = "tf-state-lock"
+encrypt        = true
+```

--- a/terraform-github-apply-2026-05-02/examples/02-actions-oidc-gcp/.github/workflows/terraform.yml
+++ b/terraform-github-apply-2026-05-02/examples/02-actions-oidc-gcp/.github/workflows/terraform.yml
@@ -1,0 +1,74 @@
+name: terraform-gcp
+
+on:
+  pull_request:
+    paths: ["terraform/**"]
+  push:
+    branches: [main]
+    paths: ["terraform/**"]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: tf-gcp-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TF_VERSION: "1.9.5"
+
+jobs:
+  plan:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: dev
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          # 例: projects/123/locations/global/workloadIdentityPools/github/providers/gh-oidc
+          service_account: ${{ vars.GCP_PLAN_SA }}
+          # 例: tf-plan@my-project.iam.gserviceaccount.com
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - run: terraform init
+      - run: terraform plan -no-color -out=tfplan
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: terraform/tfplan
+
+  apply:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: []
+    runs-on: ubuntu-latest
+    environment: prd
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_APPLY_SA }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - run: terraform init
+      - run: terraform apply -auto-approve

--- a/terraform-github-apply-2026-05-02/examples/02-actions-oidc-gcp/README.md
+++ b/terraform-github-apply-2026-05-02/examples/02-actions-oidc-gcp/README.md
@@ -1,0 +1,41 @@
+# 例 2: GitHub Actions + Workload Identity Federation (GCP)
+
+GCP 側で **Workload Identity Pool / Provider** を作り、GitHub OIDC を信頼させる。
+GitHub Secrets に Service Account key を入れる必要が無くなる。
+
+## GCP 側 (一度だけ)
+
+```hcl
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = "github"
+}
+
+resource "google_iam_workload_identity_pool_provider" "gh_oidc" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "gh-oidc"
+  oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+  }
+  # 必ず repo / branch で絞る (これを忘れると他リポジトリからも引ける)
+  attribute_condition = "assertion.repository == 'ORG/REPO'"
+}
+
+resource "google_service_account" "tf_apply" {
+  account_id = "tf-apply"
+}
+
+resource "google_service_account_iam_member" "apply_binding" {
+  service_account_id = google_service_account.tf_apply.name
+  role               = "roles/iam.workloadIdentityUser"
+  member = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/ORG/REPO"
+}
+```
+
+## ポイント
+
+- `attribute_condition` で **必ず repository / branch を絞る** こと
+- plan 用 SA と apply 用 SA を分けて、apply 用は `attribute.ref == 'refs/heads/main'` で絞る
+- State backend は GCS。GCS は native lock があるので DynamoDB 相当不要

--- a/terraform-github-apply-2026-05-02/examples/03-atlantis/README.md
+++ b/terraform-github-apply-2026-05-02/examples/03-atlantis/README.md
@@ -1,0 +1,47 @@
+# 例 3: Atlantis (PR コメント駆動)
+
+PR で `atlantis plan` / `atlantis apply` とコメントするとサーバが受け取り apply する。
+
+## 構成
+
+```
+GitHub ──webhook──▶ Atlantis Server (ECS / EKS / EC2)
+                          │
+                          ├─ plan / apply 実行 (IRSA で AWS API)
+                          ├─ tfstate (S3 + DynamoDB)
+                          └─ 結果を PR にコメント
+```
+
+## デプロイ例 (ECS Fargate)
+
+- ALB (HTTPS, 443) ─▶ Atlantis Container (4141)
+- GitHub App (webhook URL = `https://atlantis.example.com/events`)
+- Task Role に AssumeRole 権限を付与し、各 environment role を引き分ける
+- `ATLANTIS_REPO_ALLOWLIST=github.com/myorg/*`
+- `ATLANTIS_GH_APP_ID` / `ATLANTIS_GH_APP_KEY_FILE` を Secrets Manager 経由で注入
+
+## 主要 ENV
+
+| 変数 | 値 |
+|---|---|
+| `ATLANTIS_REPO_ALLOWLIST` | 許可 repo パターン |
+| `ATLANTIS_GH_APP_ID` | GitHub App ID |
+| `ATLANTIS_GH_WEBHOOK_SECRET` | webhook 署名検証用 |
+| `ATLANTIS_REPO_CONFIG` | サーバ側 atlantis.yaml |
+| `ATLANTIS_WRITE_GIT_CREDS` | true (Atlantis が一時的に git creds を書く) |
+
+## サーバ側 repo config (`server-atlantis.yaml`)
+
+```yaml
+repos:
+  - id: /.*/
+    apply_requirements: [approved, mergeable]
+    allowed_overrides: [workflow, apply_requirements]
+    allow_custom_workflows: true
+```
+
+## このパターンが向くケース
+
+- 複数 repo / 複数 workspace を中央集約したい
+- PR コメント上で plan diff を読みたい (Atlantis のフォーマットが見やすい)
+- private network 内クラスタに Terraform したい (Atlantis を VPC 内に置ける)

--- a/terraform-github-apply-2026-05-02/examples/03-atlantis/atlantis.yaml
+++ b/terraform-github-apply-2026-05-02/examples/03-atlantis/atlantis.yaml
@@ -1,0 +1,44 @@
+version: 3
+automerge: false
+parallel_plan: true
+parallel_apply: false  # apply は直列化して state ロック衝突を避ける
+
+projects:
+  - name: network-prd
+    dir: terraform/network
+    workspace: prd
+    workflow: prd
+    apply_requirements: [approved, mergeable, undiverged]
+    autoplan:
+      when_modified: ["*.tf", "../modules/**/*.tf", "prd.tfvars"]
+      enabled: true
+
+  - name: network-dev
+    dir: terraform/network
+    workspace: dev
+    workflow: dev
+    apply_requirements: [mergeable]
+    autoplan:
+      when_modified: ["*.tf", "../modules/**/*.tf", "dev.tfvars"]
+
+workflows:
+  prd:
+    plan:
+      steps:
+        - init
+        - run: tflint
+        - run: tfsec .
+        - plan:
+            extra_args: ["-var-file=prd.tfvars"]
+    apply:
+      steps:
+        - apply
+  dev:
+    plan:
+      steps:
+        - init
+        - plan:
+            extra_args: ["-var-file=dev.tfvars"]
+    apply:
+      steps:
+        - apply

--- a/terraform-github-apply-2026-05-02/examples/04-tfc-vcs/README.md
+++ b/terraform-github-apply-2026-05-02/examples/04-tfc-vcs/README.md
@@ -1,0 +1,50 @@
+# 例 4: Terraform Cloud / HCP Terraform (VCS-driven)
+
+## フロー
+
+```
+PR open  ──▶ TFC が plan を自動実行 (Speculative plan)
+              │
+              └─ 結果を PR の checks に表示 + TFC UI に Run 作成
+push to main ──▶ TFC が plan を実行 → "Confirm & Apply" ボタン
+              │
+人間が承認 ──▶ TFC が apply
+              │
+              └─ Slack/Email 通知
+```
+
+## メリット
+
+- **State / lock / 履歴 / 監査ログ** がすべて TFC 内に統合
+- **Sentinel / OPA** でポリシー違反を apply 前に止められる (ex: t3.xlarge 以上禁止)
+- **Dynamic Provider Credentials** (OIDC) で AWS / GCP / Vault のクレデンシャルを TFC が短期発行
+  - `TFC_AWS_RUN_ROLE_ARN` を env var に入れるだけで OIDC 連携が動く
+- **Run task** で TFLint / Checkov / Snyk / カスタム Webhook をフックできる
+- **No-Code モジュール** で開発者がフォームから workspace を作れる
+
+## デメリット
+
+- 月額課金 (Standard / Plus tier で機能差)
+- TFC が落ちると apply できない
+- カスタムが効きにくい部分は GH Actions と併用
+
+## ハイブリッド: GH Actions から TFC API を叩く
+
+```yaml
+- name: Trigger TFC run
+  run: |
+    curl -X POST https://app.terraform.io/api/v2/runs \
+      -H "Authorization: Bearer ${{ secrets.TFC_TOKEN }}" \
+      -H "Content-Type: application/vnd.api+json" \
+      -d '{
+        "data": {
+          "attributes": {"is-destroy": false, "message": "from gha"},
+          "type": "runs",
+          "relationships": {
+            "workspace": {"data": {"type": "workspaces", "id": "ws-xxx"}}
+          }
+        }
+      }'
+```
+
+これで Actions の workflow_dispatch から TFC の Run を発火できる。

--- a/terraform-github-apply-2026-05-02/examples/04-tfc-vcs/main.tf
+++ b/terraform-github-apply-2026-05-02/examples/04-tfc-vcs/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  cloud {
+    organization = "my-org"
+    workspaces {
+      name = "network-prd"
+    }
+  }
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}
+
+# Workspace を Terraform 自身でコード管理する例
+resource "tfe_workspace" "network_prd" {
+  name              = "network-prd"
+  organization      = "my-org"
+  terraform_version = "1.9.5"
+
+  vcs_repo {
+    identifier     = "ORG/REPO"
+    branch         = "main"
+    oauth_token_id = var.tfc_github_oauth_token_id
+  }
+
+  working_directory   = "terraform/network"
+  auto_apply          = false   # ★ apply は手動承認 (TFC UI)
+  file_triggers_enabled = true
+  trigger_prefixes    = ["terraform/network", "terraform/modules"]
+}
+
+resource "tfe_variable" "aws_region" {
+  workspace_id = tfe_workspace.network_prd.id
+  category     = "terraform"
+  key          = "aws_region"
+  value        = "ap-northeast-1"
+}
+
+resource "tfe_variable" "aws_role_arn" {
+  workspace_id = tfe_workspace.network_prd.id
+  category     = "env"
+  key          = "TFC_AWS_RUN_ROLE_ARN"  # ★ TFC Dynamic Credentials (OIDC)
+  value        = "arn:aws:iam::111122223333:role/tfc-apply"
+}

--- a/terraform-github-apply-2026-05-02/examples/05-self-hosted-runner/.github/workflows/terraform.yml
+++ b/terraform-github-apply-2026-05-02/examples/05-self-hosted-runner/.github/workflows/terraform.yml
@@ -1,0 +1,38 @@
+name: terraform-private
+
+on:
+  pull_request:
+    paths: ["terraform/**"]
+  push:
+    branches: [main]
+    paths: ["terraform/**"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: tf-private-${{ github.ref }}
+
+jobs:
+  apply:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, terraform, prd]   # ★ VPC 内ランナー
+    environment: prd
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      # IRSA でランナー Pod に IAM が付いている前提 (sts:AssumeRole 不要)
+      - name: Show identity
+        run: aws sts get-caller-identity
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.5"
+
+      - run: terraform init
+      # private EKS / RDS proxy など、ランナーが VPC 内なので到達できる
+      - run: terraform apply -auto-approve

--- a/terraform-github-apply-2026-05-02/examples/05-self-hosted-runner/README.md
+++ b/terraform-github-apply-2026-05-02/examples/05-self-hosted-runner/README.md
@@ -1,0 +1,46 @@
+# 例 5: Self-hosted Runner (VPC 内ランナー)
+
+GitHub Actions ジョブを **自 VPC 内** で動かすパターン。
+基本は例 1 と同じだが、`runs-on:` を `[self-hosted, terraform]` にする。
+
+## 構成
+
+```
+GitHub Actions ─▶ self-hosted runner (EKS / EC2 ASG)
+                  ├── private subnet
+                  ├── IRSA で IAM Role を直付け (OIDC 不要)
+                  └── EKS API server / RDS proxy / on-prem に到達可
+```
+
+## おすすめ: Actions Runner Controller (ARC) on EKS
+
+```yaml
+# RunnerScaleSet (例)
+apiVersion: actions.github.com/v1alpha1
+kind: AutoscalingRunnerSet
+metadata:
+  name: terraform-prd
+spec:
+  githubConfigUrl: https://github.com/ORG/REPO
+  githubConfigSecret: gh-app-secret  # GitHub App credential
+  template:
+    spec:
+      serviceAccountName: tf-apply-sa  # IRSA bind
+      containers:
+        - name: runner
+          image: ghcr.io/actions/actions-runner:latest
+  minRunners: 0
+  maxRunners: 5
+```
+
+## このパターンが必要な典型ケース
+
+- **private endpoint しか持たない EKS / GKE** に kubectl / helm provider で apply
+- **RDS / Redshift / OpenSearch** に Terraform 経由で SQL 実行
+- **AWS Direct Connect / VPN 越し** の on-prem リソース
+- 企業 Proxy / IP allowlist の都合で固定 IP が必要
+
+## 注意
+
+- runner ホストはコード実行されるので、isolation を強く保つ (ephemeral runner 推奨)
+- 外部 PR からの fork で self-hosted runner が使われると危険 → `if: github.event.pull_request.head.repo.full_name == github.repository` でガード


### PR DESCRIPTION
## Summary

GitHub から `terraform apply` を実行する方法のアイディア提案集を `terraform-github-apply-2026-05-02/` 配下に追加。

- `README.md` … パターン比較表 + 推奨パターン (GH Actions + OIDC + Environments + PR-driven)
- `docs/decision-matrix.md` … 選択フローチャート
- `examples/01-actions-oidc-aws/` … 推奨: AWS + OIDC + plan/apply role 分離
- `examples/02-actions-oidc-gcp/` … GCP + Workload Identity Federation
- `examples/03-atlantis/` … PR コメント駆動 (`atlantis plan`/`apply`)
- `examples/04-tfc-vcs/` … Terraform Cloud VCS 連携 + Dynamic Credentials
- `examples/05-self-hosted-runner/` … VPC 内ランナー (private endpoint 用)

## 推奨

通常用途は **GitHub Actions + OIDC + GitHub Environments の Required reviewers** が長寿命キーレスで運用しやすい。
PR コメントで全部完結させたい / 中央集約したい場合は **Atlantis**、規制要件が強い場合は **Terraform Cloud + Sentinel** を選ぶ。

## Test plan

- [ ] `README.md` のパターン比較・選択指針が要件に合っているか確認
- [ ] 例 1 (OIDC AWS) を実 repo へ移植する場合の修正箇所 (`vars.AWS_PLAN_ROLE_ARN` 等) を洗い出す
- [ ] 必要なら例 6 (`workflow_dispatch` 緊急 apply) を追加するか検討

https://claude.ai/code/session_018YgUzbAgW2sVwfwQToMtnD

---
_Generated by [Claude Code](https://claude.ai/code/session_018YgUzbAgW2sVwfwQToMtnD)_