### PR TITLE
Add Pages landing index, move rust-leptos to subpath

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,7 +1,8 @@
 # GitHub Pages にこのリポジトリ配下の各プロジェクトをまとめてデプロイする。
 #
 # サイトレイアウト:
-#   /sandbox/                                       -> rust-leptos (既存。dist-release を直置き)
+#   /sandbox/                                       -> 各サブサイトへのリンクをまとめたランディングページ (pages-index/)
+#   /sandbox/rust-leptos-start-trunk-2025-08-22/    -> rust-leptos (dist-release を直置き)
 #   /sandbox/book-mindmap-explorer-2026-05-03/      -> Vite + React の book mind map explorer
 #
 # rust-leptos は既に dist-release/ が git にコミットされているのでビルド不要。
@@ -51,8 +52,11 @@ jobs:
         run: |
           set -eux
           mkdir -p _site
-          # rust-leptos をルートに展開 (既存 URL 維持)
-          cp -r rust-leptos-start-trunk-2025-08-22/dist-release/. _site/
+          # ランディングページをルートに配置
+          cp -r pages-index/. _site/
+          # rust-leptos をサブディレクトリに配置
+          mkdir -p _site/rust-leptos-start-trunk-2025-08-22
+          cp -r rust-leptos-start-trunk-2025-08-22/dist-release/. _site/rust-leptos-start-trunk-2025-08-22/
           # book mind map をサブディレクトリに配置
           mkdir -p _site/book-mindmap-explorer-2026-05-03
           cp -r book-mindmap-explorer-2026-05-03/dist/. _site/book-mindmap-explorer-2026-05-03/

--- a/pages-index/index.html
+++ b/pages-index/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>sandbox</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --fg: #1a1a1a;
+      --bg: #fafafa;
+      --muted: #666;
+      --border: #ddd;
+      --accent: #2563eb;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --fg: #eaeaea;
+        --bg: #111;
+        --muted: #999;
+        --border: #2a2a2a;
+        --accent: #60a5fa;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 2rem 1rem;
+      font-family: system-ui, -apple-system, "Segoe UI", "Helvetica Neue", sans-serif;
+      color: var(--fg);
+      background: var(--bg);
+      line-height: 1.6;
+    }
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+    }
+    h1 {
+      margin: 0 0 0.5rem;
+      font-size: 1.75rem;
+    }
+    p.lead {
+      margin: 0 0 2rem;
+      color: var(--muted);
+    }
+    ul.projects {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+    ul.projects li {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      background: transparent;
+      transition: border-color 0.15s;
+    }
+    ul.projects li:hover {
+      border-color: var(--accent);
+    }
+    ul.projects a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 600;
+    }
+    ul.projects a:hover {
+      text-decoration: underline;
+    }
+    ul.projects .desc {
+      display: block;
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-top: 0.25rem;
+    }
+    footer {
+      margin-top: 3rem;
+      color: var(--muted);
+      font-size: 0.85rem;
+    }
+    footer a { color: inherit; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>sandbox</h1>
+    <p class="lead">pollenjp-org/sandbox にぶら下がっている小さなプロジェクト一覧。</p>
+
+    <ul class="projects">
+      <li>
+        <a href="./rust-leptos-start-trunk-2025-08-22/">rust-leptos-start-trunk-2025-08-22</a>
+        <span class="desc">Rust + Leptos + Trunk のスタータ。</span>
+      </li>
+      <li>
+        <a href="./book-mindmap-explorer-2026-05-03/">book-mindmap-explorer-2026-05-03</a>
+        <span class="desc">Vite + React で作った book mind map explorer。</span>
+      </li>
+    </ul>
+
+    <footer>
+      <a href="https://github.com/pollenjp-org/sandbox">GitHub: pollenjp-org/sandbox</a>
+    </footer>
+  </main>
+</body>
+</html>

--- a/rust-leptos-start-trunk-2025-08-22/Trunk.toml
+++ b/rust-leptos-start-trunk-2025-08-22/Trunk.toml
@@ -8,7 +8,7 @@ release = false
 # The output dir for all final assets.
 dist = "dist"
 # The public URL from which assets are to be served.
-public_url = "/sandbox/"
+public_url = "/sandbox/rust-leptos-start-trunk-2025-08-22/"
 # Whether to include hash values in the output file names.
 filehash = true
 # Whether to inject scripts (and module preloads) into the finalized output.

--- a/rust-leptos-start-trunk-2025-08-22/dist-release/index.html
+++ b/rust-leptos-start-trunk-2025-08-22/dist-release/index.html
@@ -4,16 +4,16 @@
 <head>
   <!-- Add a plain CSS file: see https://trunkrs.dev/assets/#css -->
   <!-- If using Tailwind with Leptos CSR, see https://trunkrs.dev/assets/#tailwind instead-->
-  <link rel="stylesheet" href="/sandbox/styles-b5eb075cb5908791.css" integrity="sha384-z81odaZQ6a5WhRrkbxOfk6unNzh76wIzcnOsVEZrWICZlAB3CP0qZHEFT9ZauTJb"/>
+  <link rel="stylesheet" href="/sandbox/rust-leptos-start-trunk-2025-08-22/styles-b5eb075cb5908791.css" integrity="sha384-z81odaZQ6a5WhRrkbxOfk6unNzh76wIzcnOsVEZrWICZlAB3CP0qZHEFT9ZauTJb"/>
 
   <!-- Include favicon in dist output: see https://trunkrs.dev/assets/#icon -->
-  <link rel="icon" href="/sandbox/favicon-e9cbd8f50cc65bf2.ico" integrity="sha384-YobgLXwtz0GhXVUTHml49p32guapVFlEG8UpQdDVN3kekOqkQi+qSXEpwp+yM4BW"/>
+  <link rel="icon" href="/sandbox/rust-leptos-start-trunk-2025-08-22/favicon-e9cbd8f50cc65bf2.ico" integrity="sha384-YobgLXwtz0GhXVUTHml49p32guapVFlEG8UpQdDVN3kekOqkQi+qSXEpwp+yM4BW"/>
 
   <!-- include support for `wasm-bindgen --weak-refs` - see: https://rustwasm.github.io/docs/wasm-bindgen/reference/weak-references.html -->
   
 <script type="module">
-import init, * as bindings from '/sandbox/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c.js';
-const wasm = await init({ module_or_path: '/sandbox/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c_bg.wasm' });
+import init, * as bindings from '/sandbox/rust-leptos-start-trunk-2025-08-22/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c.js';
+const wasm = await init({ module_or_path: '/sandbox/rust-leptos-start-trunk-2025-08-22/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c_bg.wasm' });
 
 
 window.wasmBindings = bindings;
@@ -22,7 +22,7 @@ window.wasmBindings = bindings;
 dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
 
 </script>
-<link rel="modulepreload" href="/sandbox/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c.js" crossorigin="anonymous" integrity="sha384-fDEK+GmuQTZu6BegBREfQ44SckkU4Vco1+10a+iuKQpE+g4l7dRHDbgHmWXNg5fA"><link rel="preload" href="/sandbox/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c_bg.wasm" crossorigin="anonymous" integrity="sha384-z3+EdvSqdU7V9EBel8bbz0ecxx8GuWX8I5M6Lg8y83g/R4vEDFswQrznSw/9Fav9" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="/sandbox/rust-leptos-start-trunk-2025-08-22/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c.js" crossorigin="anonymous" integrity="sha384-fDEK+GmuQTZu6BegBREfQ44SckkU4Vco1+10a+iuKQpE+g4l7dRHDbgHmWXNg5fA"><link rel="preload" href="/sandbox/rust-leptos-start-trunk-2025-08-22/rust-leptos-start-trunk-2025-08-22-2ab781861c105e8c_bg.wasm" crossorigin="anonymous" integrity="sha384-z3+EdvSqdU7V9EBel8bbz0ecxx8GuWX8I5M6Lg8y83g/R4vEDFswQrznSw/9Fav9" as="fetch" type="application/wasm"></head>
 
 <body></body>
 


### PR DESCRIPTION
## Summary

GitHub Pages のサイト構成を再編。

| URL | 中身 |
| --- | --- |
| `/sandbox/` | 各サブサイトへのリンクをまとめたランディングページ (`pages-index/`) |
| `/sandbox/rust-leptos-start-trunk-2025-08-22/` | rust-leptos (既存。サブパスへ移動) |
| `/sandbox/book-mindmap-explorer-2026-05-03/` | book mind map explorer (Vite + React) |

## Changes

- `pages-index/index.html` を新規作成。`/sandbox/` 直下に置く軽量なランディング。
- `rust-leptos-start-trunk-2025-08-22/Trunk.toml`: `public_url` を `/sandbox/` → `/sandbox/rust-leptos-start-trunk-2025-08-22/` に更新。
- `rust-leptos-start-trunk-2025-08-22/dist-release/index.html`: コミット済みビルド成果物のアセットパスを新しいサブパスへ書き換え。SRI ハッシュは内容ベースなので URL 変更だけなら影響なし。
- `.github/workflows/static.yml`: assemble ステップを更新。ランディングを `_site/` ルートへ、rust-leptos を `_site/rust-leptos-start-trunk-2025-08-22/` へコピー。
- VITE_BASE は元々正しかったので変更なし。

## Test plan

- [ ] このブランチを main にマージ後、`Deploy static content to Pages` workflow が成功すること
- [ ] `https://pollenjp-org.github.io/sandbox/` でランディングが表示され、両サブサイトへのリンクが機能する
- [ ] `https://pollenjp-org.github.io/sandbox/rust-leptos-start-trunk-2025-08-22/` で leptos アプリが起動する (wasm/js/css の 404 が出ない)
- [ ] `https://pollenjp-org.github.io/sandbox/book-mindmap-explorer-2026-05-03/` で book mind map が起動する

https://claude.ai/code/session_01TyH6BNtZWaZXieWCP9KHc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyH6BNtZWaZXieWCP9KHc3)_