### PR TITLE
chore: exclude CHANGELOG.md from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
## Summary
- ルートに `.prettierignore` を追加し、`CHANGELOG.md` を prettier の対象外に設定

## Test plan
- [ ] prettier 実行時に `CHANGELOG.md` がフォーマット対象外になることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsDjHHakCGTSVY2rjpRmHD)_