### PR TITLE
Add drawio MCP usage sample

### DIFF
--- a/drawio-mcp-sample-2026-05-09/README.md
+++ b/drawio-mcp-sample-2026-05-09/README.md
@@ -1,0 +1,100 @@
+# draw.io MCP サンプル
+
+draw.io (diagrams.net) を MCP (Model Context Protocol) 経由で AI アシスタント
+(Claude Code / Claude Desktop など) から使うためのサンプルです。
+
+公式実装である [`jgraph/drawio-mcp`](https://github.com/jgraph/drawio-mcp) の
+**MCP Tool Server** (`@drawio/mcp`) の使い方をまとめています。
+
+## drawio MCP は何をしてくれるか
+
+AI が生成した「diagram の XML / CSV / Mermaid」を、draw.io エディタに
+ワンクリックで開ける URL に変換し、ブラウザで開きます。
+AI に「アーキテクチャ図を描いて」と依頼すると、draw.io 上で編集可能な状態の
+図がそのまま立ち上がる、というのが基本の体験です。
+
+提供されるツールは 3 つです (公式 README より):
+
+| Tool                  | 用途                                          |
+| --------------------- | --------------------------------------------- |
+| `open_drawio_xml`     | draw.io ネイティブ XML を開く                 |
+| `open_drawio_csv`     | CSV (ノードリスト) から図を生成して開く       |
+| `open_drawio_mermaid` | Mermaid 記法を draw.io に変換して開く         |
+
+共通パラメータ:
+
+- `content` (string, required): 本体
+- `lightbox` (bool, optional): lightbox モード
+- `dark` ("auto" | "true" | "false", optional): ダークモード
+
+## セットアップ
+
+### 1. 前提
+
+- Node.js 18+ (npx が動けば OK)
+- AI クライアント (Claude Code / Claude Desktop など)
+
+### 2. 動作確認 (任意)
+
+サーバ単体を立ち上げて、起動するかだけ確認できます。
+
+```bash
+npx -y @drawio/mcp
+```
+
+通常は MCP クライアント側から起動させるので、ここで Ctrl-C で止めて OK。
+
+### 3. MCP クライアントに登録
+
+#### Claude Code
+
+`~/.claude.json` (またはプロジェクトの `.mcp.json`) に
+[`config/claude-code.mcp.json`](./config/claude-code.mcp.json) の内容を
+追記します。CLI からも登録できます:
+
+```bash
+claude mcp add drawio -- npx -y @drawio/mcp
+```
+
+#### Claude Desktop
+
+設定ファイルに [`config/claude-desktop.json`](./config/claude-desktop.json) を
+マージします。
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+### 4. 使ってみる
+
+AI クライアントに以下のようなプロンプトを投げます:
+
+> `examples/architecture.xml` の内容で draw.io を開いて
+
+> `examples/orgchart.csv` を draw.io で図にして
+
+> `examples/sequence.mmd` の Mermaid を draw.io で開いて
+
+AI 側はそれぞれ `open_drawio_xml` / `open_drawio_csv` / `open_drawio_mermaid`
+ツールを呼び、ブラウザに draw.io エディタを開きます。
+
+## サンプルファイル
+
+- [examples/architecture.xml](./examples/architecture.xml)
+  AWS 風のシンプルな 3 層アーキテクチャ (XML)
+- [examples/orgchart.csv](./examples/orgchart.csv)
+  CSV から組織図を生成するサンプル
+- [examples/sequence.mmd](./examples/sequence.mmd)
+  ログイン処理のシーケンス図 (Mermaid)
+- [examples/flowchart.mmd](./examples/flowchart.mmd)
+  CI/CD パイプラインのフローチャート (Mermaid)
+
+## 参考にするプロンプト集
+
+[`prompts.md`](./prompts.md) に、AI に投げると drawio MCP のツールを
+うまく呼んでくれる例文を置いています。
+
+## 参考リンク
+
+- [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) - 公式
+- [`@drawio/mcp` on npm](https://www.npmjs.com/package/@drawio/mcp)
+- [Hosted MCP App Server](https://mcp.draw.io/mcp) (チャット内に図を埋め込む別実装)

--- a/drawio-mcp-sample-2026-05-09/README.md
+++ b/drawio-mcp-sample-2026-05-09/README.md
@@ -81,12 +81,35 @@ AI 側はそれぞれ `open_drawio_xml` / `open_drawio_csv` / `open_drawio_merma
 
 - [examples/architecture.xml](./examples/architecture.xml)
   AWS 風のシンプルな 3 層アーキテクチャ (XML)
+- [examples/architecture.drawio.svg](./examples/architecture.drawio.svg)
+  上の XML を可視化しつつ、`content="..."` 属性に元の mxfile を埋め込んだ
+  「再編集可能 SVG」。draw.io でそのまま開いて編集できる
 - [examples/orgchart.csv](./examples/orgchart.csv)
   CSV から組織図を生成するサンプル
 - [examples/sequence.mmd](./examples/sequence.mmd)
   ログイン処理のシーケンス図 (Mermaid)
 - [examples/flowchart.mmd](./examples/flowchart.mmd)
   CI/CD パイプラインのフローチャート (Mermaid)
+
+## `.drawio.svg` を生成する
+
+注意: **`@drawio/mcp` 自体には SVG/PNG への書き出しツールは無い**。
+`open_drawio_xml` 等は draw.io エディタを開く URL を返すだけで、書き出しは
+ブラウザ上で手動 (`File > Export As > SVG (Editable)`) または公式の
+`drawio-desktop` (Electron) CLI を別途使うことになる。
+
+このリポジトリには軽量な代替として、mxfile XML から `.drawio.svg`
+(再編集可能 SVG) を生成する短い Node スクリプトを置いてある:
+
+```bash
+cd scripts
+npm install
+node render-drawio-svg.mjs ../examples/architecture.xml ../examples/architecture.drawio.svg
+```
+
+ポイントは SVG ルートに `content="<エスケープした mxfile>"` 属性を付けること。
+draw.io はこの属性付き SVG を「画像」ではなく「編集可能な diagram」として
+読み込む — これが `.drawio.svg` 形式の実体。
 
 ## 参考にするプロンプト集
 

--- a/drawio-mcp-sample-2026-05-09/config/claude-code.mcp.json
+++ b/drawio-mcp-sample-2026-05-09/config/claude-code.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "drawio": {
+      "command": "npx",
+      "args": ["-y", "@drawio/mcp"]
+    }
+  }
+}

--- a/drawio-mcp-sample-2026-05-09/config/claude-desktop.json
+++ b/drawio-mcp-sample-2026-05-09/config/claude-desktop.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "drawio": {
+      "command": "npx",
+      "args": ["-y", "@drawio/mcp"]
+    }
+  }
+}

--- a/drawio-mcp-sample-2026-05-09/examples/architecture.drawio.svg
+++ b/drawio-mcp-sample-2026-05-09/examples/architecture.drawio.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="720" height="220" viewBox="0 0 720 220" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;
+  &lt;diagram name=&quot;Architecture&quot; id=&quot;arch&quot;&gt;
+    &lt;mxGraphModel dx=&quot;800&quot; dy=&quot;600&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;850&quot; pageHeight=&quot;1100&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;
+      &lt;root&gt;
+        &lt;mxCell id=&quot;0&quot;/&gt;
+        &lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;
+
+        &lt;mxCell id=&quot;user&quot; value=&quot;User&quot; style=&quot;shape=mscae/user;html=1;fillColor=#0079D7;strokeColor=#ffffff;fontColor=#ffffff;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;40&quot; y=&quot;60&quot; width=&quot;60&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+
+        &lt;mxCell id=&quot;alb&quot; value=&quot;ALB&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;180&quot; y=&quot;60&quot; width=&quot;120&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+
+        &lt;mxCell id=&quot;ec2&quot; value=&quot;EC2 (App)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;380&quot; y=&quot;60&quot; width=&quot;120&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+
+        &lt;mxCell id=&quot;rds&quot; value=&quot;RDS (Postgres)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;580&quot; y=&quot;60&quot; width=&quot;140&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+
+        &lt;mxCell id=&quot;s3&quot; value=&quot;S3 (Static)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;
+          &lt;mxGeometry x=&quot;380&quot; y=&quot;180&quot; width=&quot;120&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+
+        &lt;mxCell id=&quot;e1&quot; style=&quot;endArrow=classic;html=1;&quot; edge=&quot;1&quot; parent=&quot;1&quot; source=&quot;user&quot; target=&quot;alb&quot;&gt;
+          &lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;e2&quot; style=&quot;endArrow=classic;html=1;&quot; edge=&quot;1&quot; parent=&quot;1&quot; source=&quot;alb&quot; target=&quot;ec2&quot;&gt;
+          &lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;e3&quot; style=&quot;endArrow=classic;html=1;&quot; edge=&quot;1&quot; parent=&quot;1&quot; source=&quot;ec2&quot; target=&quot;rds&quot;&gt;
+          &lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+        &lt;mxCell id=&quot;e4&quot; style=&quot;endArrow=classic;html=1;&quot; edge=&quot;1&quot; parent=&quot;1&quot; source=&quot;ec2&quot; target=&quot;s3&quot;&gt;
+          &lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;
+        &lt;/mxCell&gt;
+      &lt;/root&gt;
+    &lt;/mxGraphModel&gt;
+  &lt;/diagram&gt;
+&lt;/mxfile&gt;">
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs>
+<rect width="100%" height="100%" fill="#ffffff"/>
+<rect x="20" y="20" width="60" height="60" rx="6" ry="6" fill="#0079D7" stroke="#ffffff" stroke-width="1.5"/>
+<text x="50" y="50" font-family="Helvetica,Arial,sans-serif" font-size="13" text-anchor="middle" dominant-baseline="middle" fill="#222">User</text>
+<rect x="160" y="20" width="120" height="60" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+<text x="220" y="50" font-family="Helvetica,Arial,sans-serif" font-size="13" text-anchor="middle" dominant-baseline="middle" fill="#222">ALB</text>
+<rect x="360" y="20" width="120" height="60" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+<text x="420" y="50" font-family="Helvetica,Arial,sans-serif" font-size="13" text-anchor="middle" dominant-baseline="middle" fill="#222">EC2 (App)</text>
+<rect x="560" y="20" width="140" height="60" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" stroke-width="1.5"/>
+<text x="630" y="50" font-family="Helvetica,Arial,sans-serif" font-size="13" text-anchor="middle" dominant-baseline="middle" fill="#222">RDS (Postgres)</text>
+<rect x="360" y="140" width="120" height="60" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+<text x="420" y="170" font-family="Helvetica,Arial,sans-serif" font-size="13" text-anchor="middle" dominant-baseline="middle" fill="#222">S3 (Static)</text>
+<line x1="50" y1="50" x2="160" y2="50" stroke="#333" stroke-width="1.5" marker-end="url(#arrow)"/>
+<line x1="220" y1="50" x2="360" y2="50" stroke="#333" stroke-width="1.5" marker-end="url(#arrow)"/>
+<line x1="420" y1="50" x2="560" y2="50" stroke="#333" stroke-width="1.5" marker-end="url(#arrow)"/>
+<line x1="420" y1="50" x2="420" y2="140" stroke="#333" stroke-width="1.5" marker-end="url(#arrow)"/>
+</svg>

--- a/drawio-mcp-sample-2026-05-09/examples/architecture.xml
+++ b/drawio-mcp-sample-2026-05-09/examples/architecture.xml
@@ -1,0 +1,43 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="Architecture" id="arch">
+    <mxGraphModel dx="800" dy="600" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <mxCell id="user" value="User" style="shape=mscae/user;html=1;fillColor=#0079D7;strokeColor=#ffffff;fontColor=#ffffff;" vertex="1" parent="1">
+          <mxGeometry x="40" y="60" width="60" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="alb" value="ALB" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="180" y="60" width="120" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="ec2" value="EC2 (App)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="380" y="60" width="120" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="rds" value="RDS (Postgres)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="580" y="60" width="140" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="s3" value="S3 (Static)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="380" y="180" width="120" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="e1" style="endArrow=classic;html=1;" edge="1" parent="1" source="user" target="alb">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e2" style="endArrow=classic;html=1;" edge="1" parent="1" source="alb" target="ec2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e3" style="endArrow=classic;html=1;" edge="1" parent="1" source="ec2" target="rds">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e4" style="endArrow=classic;html=1;" edge="1" parent="1" source="ec2" target="s3">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/drawio-mcp-sample-2026-05-09/examples/flowchart.mmd
+++ b/drawio-mcp-sample-2026-05-09/examples/flowchart.mmd
@@ -1,0 +1,12 @@
+flowchart LR
+    A[Push to main] --> B{Lint & Test}
+    B -- fail --> X[Notify Slack]
+    B -- pass --> C[Build image]
+    C --> D[Push to ECR]
+    D --> E{Env?}
+    E -- staging --> F[Deploy to staging]
+    E -- prod --> G[Manual approval]
+    G --> H[Deploy to prod]
+    F --> I[Run smoke tests]
+    H --> I
+    I --> J[Done]

--- a/drawio-mcp-sample-2026-05-09/examples/orgchart.csv
+++ b/drawio-mcp-sample-2026-05-09/examples/orgchart.csv
@@ -1,0 +1,22 @@
+## drawio CSV import format
+## https://www.drawio.com/doc/faq/import-from-csv-builds-graph
+#
+# label: %name%<br><i style="color:gray;">%role%</i>
+# style: rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;
+# parentstyle: rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;
+# width: 160
+# height: 50
+# layout: verticaltree
+# nodespacing: 20
+# levelspacing: 60
+# edgespacing: 20
+# connect: {"from":"manager","to":"id","invert":true,"style":"endArrow=none;"}
+#
+id,name,role,manager
+1,Alice,CEO,
+2,Bob,CTO,1
+3,Carol,VP Eng,2
+4,Dave,VP Data,2
+5,Eve,EM Backend,3
+6,Frank,EM Frontend,3
+7,Grace,EM ML,4

--- a/drawio-mcp-sample-2026-05-09/examples/sequence.mmd
+++ b/drawio-mcp-sample-2026-05-09/examples/sequence.mmd
@@ -1,0 +1,20 @@
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant FE as Frontend
+    participant BE as Backend
+    participant DB as Database
+    participant IdP as Identity Provider
+
+    U->>FE: Click "Login"
+    FE->>IdP: Redirect to OAuth
+    IdP-->>U: Show login form
+    U->>IdP: Submit credentials
+    IdP-->>FE: Redirect with code
+    FE->>BE: POST /auth/callback (code)
+    BE->>IdP: Exchange code for token
+    IdP-->>BE: access_token, id_token
+    BE->>DB: Upsert user
+    DB-->>BE: user row
+    BE-->>FE: Set session cookie
+    FE-->>U: Show dashboard

--- a/drawio-mcp-sample-2026-05-09/prompts.md
+++ b/drawio-mcp-sample-2026-05-09/prompts.md
@@ -1,0 +1,48 @@
+# プロンプト例
+
+drawio MCP の各ツールを呼ばせるための例文。
+このディレクトリで Claude Code を起動した状態を想定しています。
+
+## XML を直接開かせる (`open_drawio_xml`)
+
+```
+examples/architecture.xml の内容を読み取って、drawio MCP の
+open_drawio_xml ツールで draw.io エディタに開いて。dark="auto" で。
+```
+
+## CSV から図を生成 (`open_drawio_csv`)
+
+```
+examples/orgchart.csv の中身を read して、drawio MCP の open_drawio_csv で
+組織図として開いて。
+```
+
+## Mermaid から変換 (`open_drawio_mermaid`)
+
+```
+examples/sequence.mmd を読んで、drawio MCP の open_drawio_mermaid で
+draw.io に開いて。
+```
+
+```
+examples/flowchart.mmd を drawio MCP で開いて。lightbox=true で。
+```
+
+## ゼロから作らせる
+
+```
+S3 + CloudFront + Lambda + DynamoDB の典型的なサーバーレス構成図を
+draw.io ネイティブ XML で作って、drawio MCP の open_drawio_xml で開いて。
+```
+
+```
+EC コマースサイトの注文 → 決済 → 発送までのシーケンス図を Mermaid で書いて、
+drawio MCP で開いて。
+```
+
+## ヒント
+
+- 「drawio MCP で開いて」と明示すると、AI がツールを呼んでくれやすい。
+- ツール名を直接書く (`open_drawio_xml` など) と、より確実。
+- 大きい図は XML を長文で生成させるよりも、Mermaid → MCP 経由で変換させた
+  方が短いプロンプトで済むことが多い。

--- a/drawio-mcp-sample-2026-05-09/scripts/.gitignore
+++ b/drawio-mcp-sample-2026-05-09/scripts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/drawio-mcp-sample-2026-05-09/scripts/package.json
+++ b/drawio-mcp-sample-2026-05-09/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "drawio-mcp-sample-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@xmldom/xmldom": "^0.9.8"
+  }
+}

--- a/drawio-mcp-sample-2026-05-09/scripts/render-drawio-svg.mjs
+++ b/drawio-mcp-sample-2026-05-09/scripts/render-drawio-svg.mjs
@@ -1,0 +1,158 @@
+// Build a `.drawio.svg` from a draw.io mxfile XML.
+//
+// drawio MCP (`@drawio/mcp`) only returns an editor URL; it does not export.
+// `drawio-desktop` (Electron) is the official exporter but unavailable in
+// this sandbox. So we:
+//   1. Parse the mxfile XML to learn each cell's geometry and label.
+//   2. Render a simple SVG (rects + arrows + labels).
+//   3. Set the SVG root's `content` attribute to the original mxfile XML.
+//      That is the key bit: draw.io recognises an SVG with `content=...`
+//      as an editable diagram and re-imports the mxfile on open.
+//
+// Usage: node render-drawio-svg.mjs <input.xml> <output.drawio.svg>
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
+
+const [, , inPath, outPath] = process.argv;
+if (!inPath || !outPath) {
+  console.error("usage: render-drawio-svg.mjs <input.xml> <output.drawio.svg>");
+  process.exit(1);
+}
+
+const xml = readFileSync(inPath, "utf8");
+const doc = new DOMParser().parseFromString(xml, "text/xml");
+
+const cells = Array.from(doc.getElementsByTagName("mxCell"));
+const nodes = new Map();
+const edges = [];
+
+for (const c of cells) {
+  const id = c.getAttribute("id");
+  const value = c.getAttribute("value") || "";
+  const isVertex = c.getAttribute("vertex") === "1";
+  const isEdge = c.getAttribute("edge") === "1";
+  const style = c.getAttribute("style") || "";
+
+  if (isVertex) {
+    const g = c.getElementsByTagName("mxGeometry")[0];
+    if (!g) continue;
+    nodes.set(id, {
+      id,
+      label: value,
+      x: +g.getAttribute("x") || 0,
+      y: +g.getAttribute("y") || 0,
+      w: +g.getAttribute("width") || 80,
+      h: +g.getAttribute("height") || 40,
+      fill: pick(style, "fillColor") || "#ffffff",
+      stroke: pick(style, "strokeColor") || "#333333",
+    });
+  } else if (isEdge) {
+    edges.push({
+      source: c.getAttribute("source"),
+      target: c.getAttribute("target"),
+    });
+  }
+}
+
+function pick(style, key) {
+  const m = style.match(new RegExp(`(?:^|;)${key}=([^;]+)`));
+  return m ? m[1] : null;
+}
+
+const pad = 20;
+const xs = [...nodes.values()].flatMap((n) => [n.x, n.x + n.w]);
+const ys = [...nodes.values()].flatMap((n) => [n.y, n.y + n.h]);
+const minX = Math.min(...xs) - pad;
+const minY = Math.min(...ys) - pad;
+const maxX = Math.max(...xs) + pad;
+const maxY = Math.max(...ys) + pad;
+const width = maxX - minX;
+const height = maxY - minY;
+
+const tx = (x) => x - minX;
+const ty = (y) => y - minY;
+
+const esc = (s) =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+const stripHtml = (s) => s.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+
+const parts = [];
+parts.push(
+  `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+    `version="1.1" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" ` +
+    // The `content` attribute makes draw.io treat this SVG as an editable diagram.
+    `content="${esc(new XMLSerializer().serializeToString(doc))}">`,
+);
+parts.push(
+  `<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" ` +
+    `markerWidth="8" markerHeight="8" orient="auto-start-reverse">` +
+    `<path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs>`,
+);
+parts.push(`<rect width="100%" height="100%" fill="#ffffff"/>`);
+
+for (const n of nodes.values()) {
+  const x = tx(n.x);
+  const y = ty(n.y);
+  parts.push(
+    `<rect x="${x}" y="${y}" width="${n.w}" height="${n.h}" rx="6" ry="6" ` +
+      `fill="${n.fill}" stroke="${n.stroke}" stroke-width="1.5"/>`,
+  );
+  parts.push(
+    `<text x="${x + n.w / 2}" y="${y + n.h / 2}" font-family="Helvetica,Arial,sans-serif" ` +
+      `font-size="13" text-anchor="middle" dominant-baseline="middle" fill="#222">` +
+      esc(stripHtml(n.label)) +
+      `</text>`,
+  );
+}
+
+for (const e of edges) {
+  const s = nodes.get(e.source);
+  const t = nodes.get(e.target);
+  if (!s || !t) continue;
+  const sx = tx(s.x + s.w / 2);
+  const sy = ty(s.y + s.h / 2);
+  const tx_ = tx(t.x + t.w / 2);
+  const ty_ = ty(t.y + t.h / 2);
+  // Trim to box edge so the arrow tip touches the rectangle, not its centre.
+  const [ex, ey] = trimToBox(sx, sy, tx_, ty_, tx(t.x), ty(t.y), t.w, t.h);
+  parts.push(
+    `<line x1="${sx}" y1="${sy}" x2="${ex}" y2="${ey}" stroke="#333" ` +
+      `stroke-width="1.5" marker-end="url(#arrow)"/>`,
+  );
+}
+
+parts.push(`</svg>`);
+writeFileSync(outPath, parts.join("\n"));
+console.log(`wrote ${outPath} (${width}x${height}, ${nodes.size} nodes, ${edges.length} edges)`);
+
+function trimToBox(sx, sy, tx, ty, bx, by, bw, bh) {
+  const dx = tx - sx;
+  const dy = ty - sy;
+  const candidates = [];
+  if (dx !== 0) {
+    const tLeft = (bx - sx) / dx;
+    const tRight = (bx + bw - sx) / dx;
+    candidates.push(tLeft, tRight);
+  }
+  if (dy !== 0) {
+    const tTop = (by - sy) / dy;
+    const tBot = (by + bh - sy) / dy;
+    candidates.push(tTop, tBot);
+  }
+  let best = 1;
+  for (const k of candidates) {
+    if (k <= 0 || k > 1) continue;
+    const x = sx + dx * k;
+    const y = sy + dy * k;
+    if (x >= bx - 0.5 && x <= bx + bw + 0.5 && y >= by - 0.5 && y <= by + bh + 0.5) {
+      if (k < best) best = k;
+    }
+  }
+  return [sx + dx * best, sy + dy * best];
+}


### PR DESCRIPTION
## Summary

`drawio-mcp-sample-2026-05-09/` 配下に、公式 [`jgraph/drawio-mcp`](https://github.com/jgraph/drawio-mcp) の MCP Tool Server (`@drawio/mcp`) を Claude Code / Claude Desktop から使うためのサンプル一式を追加。

- `README.md`: drawio MCP の概要、提供される 3 ツール (`open_drawio_xml` / `open_drawio_csv` / `open_drawio_mermaid`)、セットアップ手順
- `config/`: Claude Code / Claude Desktop それぞれの `mcpServers` 設定 JSON
- `examples/`: XML / CSV / Mermaid (sequence, flowchart) の入力サンプル
- `prompts.md`: 各ツールを呼ばせるためのプロンプト例

## Test plan

- [ ] `npx -y @drawio/mcp` が起動することを確認
- [ ] Claude Code に `config/claude-code.mcp.json` の設定でサーバ登録 (`claude mcp add drawio -- npx -y @drawio/mcp`)
- [ ] `prompts.md` の各プロンプトを投げて `examples/*` がブラウザで draw.io 上に開くことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_017MtpTGqiwAnVnjGqmk1uGP)_