### PR TITLE
Gemini on Agent Platform vs Agent Runtime demo (Go)

### DIFF
--- a/gemini-platform-vs-runtime-2026-05-14/README.md
+++ b/gemini-platform-vs-runtime-2026-05-14/README.md
@@ -1,0 +1,114 @@
+# Gemini on Agent Platform vs Agent Runtime
+
+April 22, 2026 の Google Cloud Next '26 で **Vertex AI** が
+**Gemini Enterprise Agent Platform** にリブランドされ、その中の
+managed runtime である **Agent Engine** が **Agent Runtime** に改名された。
+このリポジトリは、この 2 つの面の使い分けを Go の最小実装で示す。
+
+| 観点 | Gemini on Agent Platform | Agent Runtime |
+| --- | --- | --- |
+| 形 | モデル呼び出し API (1 関数) | デプロイ済みエージェントの managed host |
+| エンドポイント | `POST /v1/models/{model}:generateContent` | `POST /v1/reasoningEngines/{id}/sessions/{sid}:query` |
+| 状態 | 完全ステートレス | サーバ側にセッション + Memory Bank |
+| 履歴 | 毎回クライアントが全件送る | サーバが保持 |
+| ツール実行 | クライアント側で実装 | サーバ側で実行 (A2A orchestration 含む) |
+| メモリ | クライアントが管理 | Memory Bank / Memory Profile |
+| デプロイ単位 | なし(モデル直叩き) | `adk deploy` でホストされた reasoning engine |
+| 典型 SDK 呼び出し (Go) | `client.Models.GenerateContent(ctx, model, contents, cfg)` | `client.ReasoningEngines.Query(ctx, id, sessionID, input)` |
+| 何を自前で実装するか | 履歴・メモリ・ツール・永続化・スケール | (基本的に) 何も |
+
+要点は、**Platform = 素の Gemini モデルにアクセスするための面**、
+**Runtime = ADK で書いたエージェントを動かす managed host**、ということ。
+両者は対立する選択肢ではなく、Runtime の中で動くエージェントが Platform を
+呼び出すという階層関係になっている。
+
+## レイアウト
+
+```
+.
+├── cmd/
+│   ├── mockserver/   両方のエンドポイントを模した HTTP サーバ
+│   ├── platform/     "Gemini on Agent Platform" デモ (ステートレス)
+│   └── runtime/      "Agent Runtime" デモ (managed session)
+└── internal/api/     共有 JSON 型 (リクエスト/レスポンス)
+```
+
+`mockserver` は実 API を再現するためのもので、決定的な fake model を
+使っているので API key なしで動く。実 SDK に置き換えるときは、
+`generateContent`/`query` を `google.golang.org/genai` および
+ADK Go client に差し替えれば構造はそのまま使える。
+
+## 動かす
+
+3 つのターミナル(または `&`)で:
+
+```sh
+# 1. mock サーバ起動
+go run ./cmd/mockserver
+
+# 2. Agent Platform クライアント (履歴は自分で持つ)
+go run ./cmd/platform
+
+# 3. Agent Runtime クライアント (履歴はサーバが持つ)
+go run ./cmd/runtime
+```
+
+### 期待出力 (Platform)
+
+```
+=== Gemini on Agent Platform: WITH client-side history ===
+user [1]:  add 30 for taxi
+model[1]:  Recorded. Running total: 30.
+user [2]:  add 50 for lunch
+model[2]:  Recorded. Running total: 80.
+user [3]:  what is the total?
+model[3]:  Total spent: 80 (breakdown: taxi=30, lunch=50)
+
+=== Gemini on Agent Platform: WITHOUT client-side history (broken) ===
+user [1]:  add 30 for taxi
+model[1]:  Recorded. Running total: 30.
+user [2]:  add 50 for lunch
+model[2]:  Recorded. Running total: 50.   <-- 前ターンの 30 が忘却されている
+user [3]:  what is the total?
+model[3]:  Total spent: 0 (breakdown: )   <-- 履歴を送らないと完全に忘れる
+```
+
+ポイント: 「ちゃんと動くケース」はクライアントが履歴をローカルに溜めて
+**毎回全部送り直している**。「壊れたケース」は最新ターンしか送らないので、
+サーバから見るとそれまでの会話が存在しない。
+
+### 期待出力 (Runtime)
+
+```
+=== Agent Runtime: session sess-1 opened ===
+user [1]: add 30 for taxi
+model[1]: Recorded. Running total: 30.
+           tools=[record_expense]  memory=map[taxi:30]  turn=1
+user [2]: add 50 for lunch
+model[2]: Recorded. Running total: 80.
+           tools=[record_expense]  memory=map[lunch:50 taxi:30]  turn=2
+user [3]: what is the total?
+model[3]: Total spent: 80 (breakdown: lunch=50, taxi=30)
+           tools=[]  memory=map[lunch:50 taxi:30]  turn=3
+```
+
+ポイント: クライアントは **毎ターン 1 メッセージしか送っていない**。
+履歴・running total・ツール実行 (`record_expense`) はすべて runtime 側で
+発生している。`memory=` で Memory Bank のスナップショットも返ってくる。
+
+## どう使い分けるか
+
+- 単発の補完・分類・要約・RAG の最後の generate 部分: **Platform** 直叩きで十分。
+  自前で書く orchestration が少なく、レイテンシも 1 hop。
+- マルチターン対話・長期記憶・ツール実行・A2A 連携・本番運用 (オートスケール,
+  observability, IAM, セッション永続化): **Runtime** にデプロイする。
+  自前で書かなくていいものが激増する代わりに、エージェントを ADK で書いて
+  `adk deploy` する必要がある。
+
+## 参考
+
+- [Introducing Gemini Enterprise Agent Platform](https://cloud.google.com/blog/products/ai-machine-learning/introducing-gemini-enterprise-agent-platform)
+- [The new Gemini Enterprise: one platform for agent development](https://cloud.google.com/blog/products/ai-machine-learning/the-new-gemini-enterprise-one-platform-for-agent-development)
+- [Gemini Enterprise Agent Platform (formerly Vertex AI)](https://cloud.google.com/products/gemini-enterprise-agent-platform)
+- [Deploy to Vertex AI Agent Engine (ADK docs)](https://google.github.io/adk-docs/deploy/agent-engine/)
+- [Vertex AI Agent Builder 2026 guide](https://uibakery.io/blog/vertex-ai-agent-builder)

--- a/gemini-platform-vs-runtime-2026-05-14/cmd/mockserver/main.go
+++ b/gemini-platform-vs-runtime-2026-05-14/cmd/mockserver/main.go
@@ -1,0 +1,177 @@
+// mockserver is a tiny HTTP server that imitates two surfaces of the
+// Gemini Enterprise Agent Platform so that the two demo clients can run
+// offline:
+//
+//   - /v1/models/{model}:generateContent  (Platform: stateless model API)
+//   - /v1/reasoningEngines/{id}:createSession                (Runtime)
+//   - /v1/reasoningEngines/{id}/sessions/{sid}:query         (Runtime)
+//
+// The "model" itself is a deterministic regex-based fake so the demos
+// produce stable output without API keys.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"example.com/geminidemo/internal/api"
+)
+
+// runtimeSession is the state the Runtime keeps on behalf of the caller.
+type runtimeSession struct {
+	userID      string
+	turnCounter int
+	expenses    map[string]int
+	history     []api.Content
+}
+
+var (
+	mu       sync.Mutex
+	sessions = map[string]*runtimeSession{}
+	nextID   = 0
+)
+
+var addExpenseRE = regexp.MustCompile(`(?i)add\s+(\d+)\s+for\s+([a-z]+)`)
+
+// fakeModel turns a flat list of user/model turns into the next assistant
+// reply. It "tools-calls" by scanning the entire visible history for
+// `add N for X` statements and summing them, so it reflects whatever
+// history the caller chose to share.
+func fakeModel(history []api.Content) (reply string, expenses map[string]int) {
+	expenses = map[string]int{}
+	var lastUser string
+	for _, c := range history {
+		if c.Role != "user" {
+			continue
+		}
+		for _, p := range c.Parts {
+			lastUser = p.Text
+			for _, m := range addExpenseRE.FindAllStringSubmatch(p.Text, -1) {
+				amount, _ := strconv.Atoi(m[1])
+				expenses[strings.ToLower(m[2])] += amount
+			}
+		}
+	}
+	total := 0
+	for _, v := range expenses {
+		total += v
+	}
+	switch {
+	case strings.Contains(strings.ToLower(lastUser), "total"):
+		parts := []string{}
+		for k, v := range expenses {
+			parts = append(parts, fmt.Sprintf("%s=%d", k, v))
+		}
+		reply = fmt.Sprintf("Total spent: %d (breakdown: %s)", total, strings.Join(parts, ", "))
+	case addExpenseRE.MatchString(lastUser):
+		reply = fmt.Sprintf("Recorded. Running total: %d.", total)
+	default:
+		reply = "I track expenses. Try: 'add 30 for taxi' or 'what is the total?'."
+	}
+	return reply, expenses
+}
+
+// ---- Platform handler: completely stateless --------------------------------
+
+func handleGenerateContent(w http.ResponseWriter, r *http.Request) {
+	var req api.GenerateContentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	reply, _ := fakeModel(req.Contents)
+	resp := api.GenerateContentResponse{}
+	resp.Candidates = append(resp.Candidates, struct {
+		Content api.Content `json:"content"`
+	}{Content: api.Content{Role: "model", Parts: []api.Part{{Text: reply}}}})
+	writeJSON(w, resp)
+}
+
+// ---- Runtime handlers: server holds the session ----------------------------
+
+func handleCreateSession(w http.ResponseWriter, r *http.Request) {
+	var req api.CreateSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	mu.Lock()
+	nextID++
+	sid := fmt.Sprintf("sess-%d", nextID)
+	sessions[sid] = &runtimeSession{userID: req.UserID, expenses: map[string]int{}}
+	mu.Unlock()
+	writeJSON(w, api.CreateSessionResponse{SessionID: sid})
+}
+
+func handleQuery(sid string, w http.ResponseWriter, r *http.Request) {
+	var req api.QueryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	s, ok := sessions[sid]
+	if !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	s.history = append(s.history, api.Content{Role: "user", Parts: []api.Part{{Text: req.Input}}})
+	reply, expenses := fakeModel(s.history)
+	s.history = append(s.history, api.Content{Role: "model", Parts: []api.Part{{Text: reply}}})
+	s.expenses = expenses
+	s.turnCounter++
+	snap := map[string]string{}
+	for k, v := range s.expenses {
+		snap[k] = strconv.Itoa(v)
+	}
+	var toolCalls []string
+	if addExpenseRE.MatchString(req.Input) {
+		toolCalls = append(toolCalls, "record_expense")
+	}
+	writeJSON(w, api.QueryResponse{
+		Output:      reply,
+		ToolCalls:   toolCalls,
+		MemorySnap:  snap,
+		TurnCounter: s.turnCounter,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func main() {
+	addr := ":8080"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, ":generateContent") {
+			http.NotFound(w, r)
+			return
+		}
+		handleGenerateContent(w, r)
+	})
+	mux.HandleFunc("/v1/reasoningEngines/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasSuffix(path, ":createSession"):
+			handleCreateSession(w, r)
+		case strings.Contains(path, "/sessions/") && strings.HasSuffix(path, ":query"):
+			// .../sessions/{sid}:query
+			i := strings.LastIndex(path, "/sessions/") + len("/sessions/")
+			j := strings.LastIndex(path, ":query")
+			handleQuery(path[i:j], w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	log.Printf("mock Agent Platform/Runtime listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/gemini-platform-vs-runtime-2026-05-14/cmd/platform/main.go
+++ b/gemini-platform-vs-runtime-2026-05-14/cmd/platform/main.go
@@ -1,0 +1,112 @@
+// platform is the "Gemini on Agent Platform" demo.
+//
+// Hits the stateless model endpoint:
+//
+//	POST /v1/models/gemini-3.1-flash:generateContent
+//
+// Key point: every turn the CLIENT must rebuild the conversation history
+// and send it in full. There is no session, no server-side memory, and no
+// server-side tool execution. If you want running totals, multi-turn
+// reasoning, or persistent memory, you implement them yourself.
+//
+// In production this is the surface the `google.golang.org/genai` SDK
+// wraps -- `client.Models.GenerateContent(ctx, model, contents, cfg)`.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"example.com/geminidemo/internal/api"
+)
+
+const model = "gemini-3.1-flash"
+
+func endpoint() string {
+	if v := os.Getenv("ENDPOINT"); v != "" {
+		return v
+	}
+	return "http://localhost:8080"
+}
+
+// generateContent is the one HTTP call the Platform surface offers.
+// Note: the entire `history` is sent every time.
+func generateContent(history []api.Content) (string, error) {
+	body, _ := json.Marshal(api.GenerateContentRequest{Contents: history})
+	url := fmt.Sprintf("%s/v1/models/%s:generateContent", endpoint(), model)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("%s: %s", resp.Status, b)
+	}
+	var out api.GenerateContentResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if len(out.Candidates) == 0 || len(out.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("empty response")
+	}
+	return out.Candidates[0].Content.Parts[0].Text, nil
+}
+
+// chatWithLocalHistory is the multi-turn pattern. The client owns the
+// history slice; the server has no idea this is a "conversation".
+func chatWithLocalHistory(prompts []string) {
+	var history []api.Content
+	for i, p := range prompts {
+		history = append(history, api.Content{
+			Role: "user", Parts: []api.Part{{Text: p}},
+		})
+		reply, err := generateContent(history)
+		if err != nil {
+			log.Fatalf("turn %d: %v", i+1, err)
+		}
+		fmt.Printf("user [%d]:  %s\n", i+1, p)
+		fmt.Printf("model[%d]:  %s\n", i+1, reply)
+		// Client must append model turn into local history so the NEXT
+		// generateContent call still has the context.
+		history = append(history, api.Content{
+			Role: "model", Parts: []api.Part{{Text: reply}},
+		})
+	}
+	fmt.Printf("\n[platform] history kept locally: %d turns; server is stateless.\n", len(history))
+}
+
+// chatStateless shows what happens if you forget that the model is
+// stateless: each call sees only the latest user message. The "running
+// total" forgets the previous turn because we never resent it.
+func chatStateless(prompts []string) {
+	for i, p := range prompts {
+		reply, err := generateContent([]api.Content{
+			{Role: "user", Parts: []api.Part{{Text: p}}},
+		})
+		if err != nil {
+			log.Fatalf("turn %d: %v", i+1, err)
+		}
+		fmt.Printf("user [%d]:  %s\n", i+1, p)
+		fmt.Printf("model[%d]:  %s   <-- only this turn's data is visible\n", i+1, reply)
+	}
+}
+
+func main() {
+	prompts := []string{
+		"add 30 for taxi",
+		"add 50 for lunch",
+		"what is the total?",
+	}
+
+	fmt.Println("=== Gemini on Agent Platform: WITH client-side history ===")
+	chatWithLocalHistory(prompts)
+
+	fmt.Println("\n=== Gemini on Agent Platform: WITHOUT client-side history (broken) ===")
+	chatStateless(prompts)
+}

--- a/gemini-platform-vs-runtime-2026-05-14/cmd/runtime/main.go
+++ b/gemini-platform-vs-runtime-2026-05-14/cmd/runtime/main.go
@@ -1,0 +1,97 @@
+// runtime is the "Agent Runtime" demo (formerly Vertex AI Agent Engine,
+// renamed in the April 2026 Gemini Enterprise Agent Platform rebrand).
+//
+// Hits the managed-agent endpoints:
+//
+//	POST /v1/reasoningEngines/{id}:createSession
+//	POST /v1/reasoningEngines/{id}/sessions/{sid}:query
+//
+// Key point: the runtime holds the session, conversation history, memory
+// bank, and tool execution. The caller sends ONE user message per turn and
+// receives back the assistant reply plus a snapshot of whatever state the
+// runtime decided to persist. Multi-turn reasoning, running totals and
+// long-term memory just work, without the client tracking anything.
+//
+// In production this is what `adk deploy` puts behind an HTTPS endpoint
+// and what the ADK client SDK (`reasoning_engine.query(...)`) wraps.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"example.com/geminidemo/internal/api"
+)
+
+const reasoningEngineID = "trip-budget-agent"
+
+func endpoint() string {
+	if v := os.Getenv("ENDPOINT"); v != "" {
+		return v
+	}
+	return "http://localhost:8080"
+}
+
+func postJSON(url string, in, out any) error {
+	body, _ := json.Marshal(in)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s: %s", resp.Status, b)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func createSession(userID string) (string, error) {
+	url := fmt.Sprintf("%s/v1/reasoningEngines/%s:createSession", endpoint(), reasoningEngineID)
+	var out api.CreateSessionResponse
+	if err := postJSON(url, api.CreateSessionRequest{UserID: userID}, &out); err != nil {
+		return "", err
+	}
+	return out.SessionID, nil
+}
+
+func query(sid, input string) (api.QueryResponse, error) {
+	url := fmt.Sprintf("%s/v1/reasoningEngines/%s/sessions/%s:query", endpoint(), reasoningEngineID, sid)
+	var out api.QueryResponse
+	err := postJSON(url, api.QueryRequest{Input: input}, &out)
+	return out, err
+}
+
+func main() {
+	sid, err := createSession("alice@example.com")
+	if err != nil {
+		log.Fatalf("createSession: %v", err)
+	}
+	fmt.Printf("=== Agent Runtime: session %s opened ===\n", sid)
+
+	prompts := []string{
+		"add 30 for taxi",
+		"add 50 for lunch",
+		"what is the total?",
+	}
+	// Note: only the latest user message is sent each call. No history is
+	// included; the runtime is keeping it for us.
+	for i, p := range prompts {
+		resp, err := query(sid, p)
+		if err != nil {
+			log.Fatalf("turn %d: %v", i+1, err)
+		}
+		fmt.Printf("user [%d]: %s\n", i+1, p)
+		fmt.Printf("model[%d]: %s\n", i+1, resp.Output)
+		fmt.Printf("           tools=%v  memory=%v  turn=%d\n",
+			resp.ToolCalls, resp.MemorySnap, resp.TurnCounter)
+	}
+
+	fmt.Println("\n[runtime] client sent 3 single-message requests;")
+	fmt.Println("          history + memory + tool execution lived on the server.")
+}

--- a/gemini-platform-vs-runtime-2026-05-14/go.mod
+++ b/gemini-platform-vs-runtime-2026-05-14/go.mod
@@ -1,0 +1,3 @@
+module example.com/geminidemo
+
+go 1.24

--- a/gemini-platform-vs-runtime-2026-05-14/internal/api/api.go
+++ b/gemini-platform-vs-runtime-2026-05-14/internal/api/api.go
@@ -1,0 +1,71 @@
+// Package api defines the request/response shapes used by the two demo clients
+// and the mock server. The shapes are simplified imitations of the real Gemini
+// Enterprise Agent Platform APIs:
+//
+//   - "Gemini on Agent Platform" (model surface, stateless):
+//     POST /v1/models/{model}:generateContent
+//     This mirrors the generative-language / Vertex AI generative SDK call:
+//     the caller sends the full conversation each turn; the server returns one
+//     completion. There is no session, memory, or tool execution on the server.
+//
+//   - "Agent Runtime" (formerly Agent Engine, managed runtime):
+//     POST /v1/reasoningEngines/{id}:createSession
+//     POST /v1/reasoningEngines/{id}/sessions/{sid}:query
+//     The server holds the session, the conversation history, the memory bank
+//     state, and runs tools on the caller's behalf. The caller just sends a
+//     single user message per turn and reads the assistant reply plus any
+//     state the runtime decided to persist.
+package api
+
+// ---- Platform: stateless model surface ------------------------------------
+
+// Content is a single role-tagged turn ("user" | "model").
+type Content struct {
+	Role  string `json:"role"`
+	Parts []Part `json:"parts"`
+}
+
+// Part is one chunk of a turn. We only model text here.
+type Part struct {
+	Text string `json:"text"`
+}
+
+// GenerateContentRequest is what the client POSTs to the model endpoint.
+// The caller must pass the FULL prior conversation every call.
+type GenerateContentRequest struct {
+	Contents []Content `json:"contents"`
+}
+
+// GenerateContentResponse is one assistant turn.
+type GenerateContentResponse struct {
+	Candidates []struct {
+		Content Content `json:"content"`
+	} `json:"candidates"`
+}
+
+// ---- Runtime: managed session surface -------------------------------------
+
+// CreateSessionRequest opens a managed session against a deployed agent.
+type CreateSessionRequest struct {
+	UserID string `json:"userId"`
+}
+
+// CreateSessionResponse returns the session id the client must reuse.
+type CreateSessionResponse struct {
+	SessionID string `json:"sessionId"`
+}
+
+// QueryRequest sends ONE user message. No history is included; the runtime
+// already has it.
+type QueryRequest struct {
+	Input string `json:"input"`
+}
+
+// QueryResponse is the assistant reply plus a snapshot of the memory the
+// runtime is keeping for this session.
+type QueryResponse struct {
+	Output      string            `json:"output"`
+	ToolCalls   []string          `json:"toolCalls"`
+	MemorySnap  map[string]string `json:"memorySnap"`
+	TurnCounter int               `json:"turnCounter"`
+}


### PR DESCRIPTION
## Summary

Adds `gemini-platform-vs-runtime-2026-05-14/` with two minimal Go clients and a mock server illustrating the difference between the two surfaces of the rebranded **Gemini Enterprise Agent Platform** (April 22, 2026 Cloud Next '26 rebrand of Vertex AI):

- **Gemini on Agent Platform** — stateless model API (`POST /v1/models/{model}:generateContent`). Client owns history, memory, tool execution. Shown both correctly (with client-side history) and incorrectly (without) to make the statelessness obvious.
- **Agent Runtime** (formerly Agent Engine) — managed runtime hosting an ADK agent. Client creates a session and sends one message per turn; the server keeps history, runs tools, and persists Memory Bank state.

Both clients target the same toy task (track running expense totals across 3 turns) so the diff is purely the architectural surface, not the task. A `mockserver` binary fakes both endpoints deterministically so the demo runs offline with no API key.

## Layout

```
gemini-platform-vs-runtime-2026-05-14/
├── cmd/{mockserver,platform,runtime}/main.go
├── internal/api/api.go    # shared JSON shapes
└── README.md              # Japanese walkthrough + sources
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go run ./cmd/mockserver` + `go run ./cmd/platform` — running totals work with history, break without
- [x] `go run ./cmd/runtime` — session-based, server keeps state, no history sent by client

https://claude.ai/code/session_01CaNtg3DE1pcUwHLF7HErZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaNtg3DE1pcUwHLF7HErZX)_