### PR TITLE
Add SessionStart hook to script the CI environment

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Mirrors the .github/workflows/static.yml CI environment so tests, linters,
+# and builds for the npm projects work inside web sessions.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+repo_root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+install_npm_project() {
+  local dir="$1"
+  if [ ! -f "${repo_root}/${dir}/package.json" ]; then
+    echo "Skipping ${dir}: no package.json"
+    return 0
+  fi
+  echo "Installing npm deps in ${dir}"
+  (cd "${repo_root}/${dir}" && npm install --no-audit --no-fund --loglevel=error)
+}
+
+install_npm_project "book-mindmap-explorer-2026-05-03"
+install_npm_project "html-text-extractor-2026-05-04"
+
+echo "SessionStart hook complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/github-ci-environment-script-2026-05-16/README.md
+++ b/github-ci-environment-script-2026-05-16/README.md
@@ -1,0 +1,20 @@
+# github-ci-environment-script-2026-05-16
+
+GitHub CI 環境を Claude Code on the web の SessionStart hook として登録するタスク。
+
+実際のファイルは repository root に配置されている (Claude Code が `.claude/` を repo root から読み込むため。`.github/` と同じ CI/CD 例外):
+
+- `/.claude/hooks/session-start.sh` — `CLAUDE_CODE_REMOTE=true` の時に CI と同じ npm 依存を install する
+- `/.claude/settings.json` — 上記スクリプトを `SessionStart` hook として登録
+
+対象プロジェクト (`.github/workflows/static.yml` の `npm ci` を踏襲):
+
+- `book-mindmap-explorer-2026-05-03/`
+- `html-text-extractor-2026-05-04/`
+
+## ローカルでの実行
+
+```bash
+chmod +x .claude/hooks/session-start.sh
+CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh
+```


### PR DESCRIPTION
## Summary
- Register `.claude/hooks/session-start.sh` as a `SessionStart` hook via `.claude/settings.json`, mirroring the `npm ci`/`npm run build` steps in `.github/workflows/static.yml` so Claude Code on the web sessions arrive with deps already installed.
- The hook is gated on `CLAUDE_CODE_REMOTE=true`, installs `book-mindmap-explorer-2026-05-03/` and `html-text-extractor-2026-05-04/`, and is idempotent (uses `npm install`, not `npm ci`, to benefit from container caching).
- Task notes live under `github-ci-environment-script-2026-05-16/README.md`; the actual hook lives at the repo root because Claude Code reads `.claude/` from there.

## Test plan
- [x] `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` completes (installs 91 + 71 packages)
- [x] `npm run typecheck` succeeds in both `book-mindmap-explorer-2026-05-03/` and `html-text-extractor-2026-05-04/`
- [x] `npm run build` succeeds in `html-text-extractor-2026-05-04/` (vite production build)
- [ ] After merge into `main`, confirm a fresh web session starts cleanly with deps preinstalled

---
_Generated by [Claude Code](https://claude.ai/code/session_012ew8UVRnfaYoAfCpLmnPEb)_